### PR TITLE
Tiers and Tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ SOFTWARE.
 There are several features planned, these include:
 
 - <s>Coverage filtering to enable only coverpoints of interest</s>
-- Improved coverage viewer (In progress)
+- <s>Tiered/tagged coverage to allow for quicker CIs, more granuality for soak regressions, etc</s>
+- <s>Improved coverage viewer</s> (In progress)
 - CI
 - Improved documentation
 - Use logging instead of print
-- Tiered coverage to allow for quicker CIs, more granuality for soak regressions, etc
 - Track which testcases contribute to coverage
 - Speed optimisations
 

--- a/bucket/base.py
+++ b/bucket/base.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2024 Vypercore. All Rights Reserved
+
+from typing import Callable
+
+from .common.chain import Link, OpenLink
+from .link import CovDef, CovRun
+
+
+class CoverBase:
+    name: str
+    full_path: str
+    description: str
+    target: int
+    hits: int
+
+    def setup(self):
+        raise NotImplementedError("This needs to be implemented by the coverpoint")
+
+    def sample(self, trace):
+        raise NotImplementedError("This needs to be implemented by the coverpoint")
+
+    def _chain_def(self, start: OpenLink[CovDef] | None = None) -> Link[CovDef]: ...
+
+    def _chain_run(self, start: OpenLink[CovRun] | None = None) -> Link[CovRun]: ...
+
+    def _apply_filter(
+        self,
+        matcher: Callable[["CoverBase"], bool],
+        match_state: bool,
+        mismatch_state: bool | None,
+    ) -> bool: ...

--- a/bucket/common/types.py
+++ b/bucket/common/types.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2024 Vypercore. All Rights Reserved
+
+from typing import Annotated
+
+from pydantic import AfterValidator
+
+
+def list_of_lower_str_validator(m_strs: str | list[str]) -> list[str]:
+    "Accept a str or list of strings and make them lowercase"
+    if isinstance(m_strs, str):
+        m_strs = [m_strs]
+    m_strs[:] = (m_str.lower() for m_str in m_strs)
+    return m_strs
+
+
+MatchStrs = Annotated[str | list[str], AfterValidator(list_of_lower_str_validator)]
+TagStrs = Annotated[str | list[str], AfterValidator(list_of_lower_str_validator)]

--- a/bucket/covergroup.py
+++ b/bucket/covergroup.py
@@ -80,11 +80,9 @@ class Covergroup(CoverBase):
     @validate_call
     def include_by_function(self, matcher: Callable[[CoverBase], bool]):
         """
-        Filter coverpoints by the provided function. Those that match are set to active.
-        If this is the first filter to be applied, then any coverpoints which do not match
-        are explicitly set to inactive, as the default state is active.
+        Enable coverpoints which match the provided function. Unmatched coverpoints will not have their active state changed, except this is the first filter to be applied, then any coverpoints which do not match are explicitly set to inactive, as the default state is active.
         Parameters:
-            matcher: A function to match against coverpoints/covergroup data
+            matcher: A function to match against coverpoint/covergroup data
         """
         mismatch_state = None
         if not self._filter_applied:
@@ -93,13 +91,21 @@ class Covergroup(CoverBase):
         return self
 
     @validate_call
+    def restrict_by_function(self, matcher: Callable[[CoverBase], bool]):
+        """
+        Filter coverpoints which match the provided function. Those that match will not change their active state, those that don't match will be set to inactive.
+        Parameters:
+            matcher: A function to match against coverpoint/covergroup data
+        """
+        self._apply_filter(matcher, None, False)
+        return self
+
+    @validate_call
     def exclude_by_function(self, matcher: Callable[[CoverBase], bool]):
         """
-        Filter coverpoints by the provided function. Those that match are set to active.
-        If this is the first filter to be applied, then any coverpoints which do not match
-        are explicitly set to inactive, as the default state is active.
+        Disable coverpoints which match the provided function. Unmatched coverpoints will not have their active state changed.
         Parameters:
-            matcher: A function to match against coverpoints/covergroup data
+            matcher: A function to match against coverpoint/covergroup data
         """
         self._apply_filter(matcher, False, None)
         return self
@@ -107,60 +113,63 @@ class Covergroup(CoverBase):
     @validate_call
     def include_by_name(self, names: MatchStrs):
         """
-        Filter the coverage tree, including coverpoints/covergroups which match.
-        If this is the first filter to be applied, then any coverpoints which do not match
-        are explicitly set to inactive, as the default state is active.
+        Enable coverpoints which match the provided names. Unmatched coverpoints will not have their active state changed, except this is the first filter to be applied, then any coverpoints which do not match are explicitly set to inactive, as the default state is active.
         Parameters:
             names: A case-insensitive string or string list to match against
         """
         return self.include_by_function(self._match_by_name(names))
 
     @validate_call
-    def exclude_by_name(self, names: MatchStrs):
+    def restrict_by_name(self, names: MatchStrs):
         """
-        Filter the coverage tree, excluding coverpoints/covergroups which match.
+        Filter coverpoints which match the provided names. Those that match will not change their active state, those that don't match will be set to inactive.
         Parameters:
             names: A case-insensitive string or string list to match against
         """
         return self.exclude_by_function(self._match_by_name(names))
 
     @validate_call
-    def include_by_tier(self, tier: int):
+    def exclude_by_name(self, names: MatchStrs):
         """
-        Filter the coverage tree, including coverpoints equal to or less than 'tier'.
-        If this is the first filter to be applied, then any coverpoints which do not match
-        are explicitly set to inactive, as the default state is active.
+        Disable coverpoints which match the provided names. Unmatched coverpoints will not have their active state changed.
+        Parameters:
+            names: A case-insensitive string or string list to match against
+        """
+        return self.exclude_by_function(self._match_by_name(names))
+
+    @validate_call
+    def set_tier_level(self, tier: int):
+        """
+        Filter the coverage tree for coverpoints equal to or less than 'tier'. Those that match will not change their active state, those that don't match will be set to inactive.
         Parameters:
             tier: The highest tier to be set active
         """
-        return self.include_by_function(self._match_by_tier(tier))
-
-    @validate_call
-    def exclude_by_tier(self, tier: int):
-        """
-        Filter the coverage tree, excluding coverpoints equal to or less than 'tier'.
-        Parameters:
-            names: A case-insensitive string or string list to match against
-            tier: The highest tier to be set inactive
-        """
-        return self.exclude_by_function(self._match_by_tier(tier))
+        return self.restrict_by_function(self._match_by_tier(tier))
 
     @validate_call
     def include_by_tags(self, tags: TagStrs, match_all: bool = False):
         """
-        Filter the coverage tree, including coverpoints matching against `tags`.
-        If this is the first filter to be applied, then any coverpoints which do not match
-        are explicitly set to inactive, as the default state is active.
+        Enable coverpoints which match the provided tags. Unmatched coverpoints will not have their active state changed, except this is the first filter to be applied, then any coverpoints which do not match are explicitly set to inactive, as the default state is active.
         Parameters:
             tags: Tag(s) to match against
             match_all: If set, all tags must match. If cleared, any tags can match (default: False)
         """
-        return self.include_by_function(self._match_by_tags(tags))
+        return self.include_by_function(self._match_by_tags(tags, match_all))
+
+    @validate_call
+    def restrict_by_tags(self, tags: TagStrs, match_all: bool = False):
+        """
+        Filter coverpoints which match the provided tags. Those that match will not change their active state, those that don't match will be set to inactive.
+        Parameters:
+            tags: Tag(s) to match against
+            match_all: If set, all tags must match. If cleared, any tags can match
+        """
+        return self.exclude_by_function(self._match_by_tags(tags))
 
     @validate_call
     def exclude_by_tags(self, tags: TagStrs, match_all: bool = False):
         """
-        Filter the coverage tree, excluding coverpoints matching against `tags`.
+        Disable coverpoints which match the provided tags. Unmatched coverpoints will not have their active state changed.
         Parameters:
             tags: Tag(s) to match against
             match_all: If set, all tags must match. If cleared, any tags can match

--- a/bucket/covergroup.py
+++ b/bucket/covergroup.py
@@ -80,7 +80,10 @@ class Covergroup(CoverBase):
     @validate_call
     def include_by_function(self, matcher: Callable[[CoverBase], bool]):
         """
-        Enable coverpoints which match the provided function. Unmatched coverpoints will not have their active state changed, except this is the first filter to be applied, then any coverpoints which do not match are explicitly set to inactive, as the default state is active.
+        Enable coverpoints which match the provided function. Unmatched coverpoints will
+        not have their active state changed, except this is the first filter to be
+        applied, then any coverpoints which do not match are explicitly set to inactive,
+        as the default state is active.
         Parameters:
             matcher: A function to match against coverpoint/covergroup data
         """
@@ -93,7 +96,8 @@ class Covergroup(CoverBase):
     @validate_call
     def restrict_by_function(self, matcher: Callable[[CoverBase], bool]):
         """
-        Filter coverpoints which match the provided function. Those that match will not change their active state, those that don't match will be set to inactive.
+        Filter coverpoints which match the provided function. Those that match will not
+        change their active state, those that don't match will be set to inactive.
         Parameters:
             matcher: A function to match against coverpoint/covergroup data
         """
@@ -103,7 +107,8 @@ class Covergroup(CoverBase):
     @validate_call
     def exclude_by_function(self, matcher: Callable[[CoverBase], bool]):
         """
-        Disable coverpoints which match the provided function. Unmatched coverpoints will not have their active state changed.
+        Disable coverpoints which match the provided function. Unmatched coverpoints will
+        not have their active state changed.
         Parameters:
             matcher: A function to match against coverpoint/covergroup data
         """
@@ -113,7 +118,10 @@ class Covergroup(CoverBase):
     @validate_call
     def include_by_name(self, names: MatchStrs):
         """
-        Enable coverpoints which match the provided names. Unmatched coverpoints will not have their active state changed, except this is the first filter to be applied, then any coverpoints which do not match are explicitly set to inactive, as the default state is active.
+        Enable coverpoints which match the provided names. Unmatched coverpoints will not
+        have their active state changed, except this is the first filter to be applied,
+        then any coverpoints which do not match are explicitly set to inactive, as the
+        default state is active.
         Parameters:
             names: A case-insensitive string or string list to match against
         """
@@ -122,7 +130,8 @@ class Covergroup(CoverBase):
     @validate_call
     def restrict_by_name(self, names: MatchStrs):
         """
-        Filter coverpoints which match the provided names. Those that match will not change their active state, those that don't match will be set to inactive.
+        Filter coverpoints which match the provided names. Those that match will not
+        change their active state, those that don't match will be set to inactive.
         Parameters:
             names: A case-insensitive string or string list to match against
         """
@@ -131,7 +140,8 @@ class Covergroup(CoverBase):
     @validate_call
     def exclude_by_name(self, names: MatchStrs):
         """
-        Disable coverpoints which match the provided names. Unmatched coverpoints will not have their active state changed.
+        Disable coverpoints which match the provided names. Unmatched coverpoints will
+        not have their active state changed.
         Parameters:
             names: A case-insensitive string or string list to match against
         """
@@ -140,7 +150,9 @@ class Covergroup(CoverBase):
     @validate_call
     def set_tier_level(self, tier: int):
         """
-        Filter the coverage tree for coverpoints equal to or less than 'tier'. Those that match will not change their active state, those that don't match will be set to inactive.
+        Filter the coverage tree for coverpoints equal to or less than 'tier'. Those that
+        match will not change their active state, those that don't match will be set to
+        inactive.
         Parameters:
             tier: The highest tier to be set active
         """
@@ -149,17 +161,22 @@ class Covergroup(CoverBase):
     @validate_call
     def include_by_tags(self, tags: TagStrs, match_all: bool = False):
         """
-        Enable coverpoints which match the provided tags. Unmatched coverpoints will not have their active state changed, except this is the first filter to be applied, then any coverpoints which do not match are explicitly set to inactive, as the default state is active.
+        Enable coverpoints which match the provided tags. Unmatched coverpoints will not
+        have their active state changed, except this is the first filter to be applied,
+        then any coverpoints which do not match are explicitly set to inactive, as the
+        default state is active.
         Parameters:
             tags: Tag(s) to match against
-            match_all: If set, all tags must match. If cleared, any tags can match (default: False)
+            match_all: If set, all tags must match.
+                       If cleared, any tags can match (default: False)
         """
         return self.include_by_function(self._match_by_tags(tags, match_all))
 
     @validate_call
     def restrict_by_tags(self, tags: TagStrs, match_all: bool = False):
         """
-        Filter coverpoints which match the provided tags. Those that match will not change their active state, those that don't match will be set to inactive.
+        Filter coverpoints which match the provided tags. Those that match will not
+        change their active state, those that don't match will be set to inactive.
         Parameters:
             tags: Tag(s) to match against
             match_all: If set, all tags must match. If cleared, any tags can match
@@ -169,7 +186,8 @@ class Covergroup(CoverBase):
     @validate_call
     def exclude_by_tags(self, tags: TagStrs, match_all: bool = False):
         """
-        Disable coverpoints which match the provided tags. Unmatched coverpoints will not have their active state changed.
+        Disable coverpoints which match the provided tags. Unmatched coverpoints will not
+        have their active state changed.
         Parameters:
             tags: Tag(s) to match against
             match_all: If set, all tags must match. If cleared, any tags can match

--- a/bucket/covergroup.py
+++ b/bucket/covergroup.py
@@ -140,7 +140,7 @@ class Covergroup(CoverBase):
     def _apply_filter(
         self,
         matcher: Callable[[CoverBase], bool],
-        match_state: bool,
+        match_state: bool | None,
         mismatch_state: bool | None,
     ):
         any_children_active = False

--- a/bucket/coverpoint.py
+++ b/bucket/coverpoint.py
@@ -121,7 +121,7 @@ class Coverpoint(CoverBase):
     ):
         if matcher(self) and match_state is not None:
             self.active = match_state
-        elif mismatch_state is not None:
+        elif not matcher(self) and mismatch_state is not None:
             self.active = mismatch_state
         return self.active
 

--- a/bucket/example.py
+++ b/bucket/example.py
@@ -22,6 +22,8 @@ class TopDogs(Covergroup):
     def setup(self, ctx):
         self.add_coverpoint(
             DogStats(name="doggy_stats", description="Some basic doggy stats")
+            .set_tier(1)
+            .set_tags(["basic", "stats"])
         )
         self.add_covergroup(
             DogsAndToys(
@@ -39,22 +41,29 @@ class DogsAndToys(Covergroup):
     def setup(self, ctx):
         self.add_coverpoint(
             ChewToysByAge(
-                name="chew_toys_by_age", description="Preferred chew toys by age"
+                name="chew_toys_by_age",
+                description="Preferred chew toys by age",
             )
+            .set_tier(5)
+            .set_tags(["toys", "age"])
         )
         self.add_coverpoint(
             ChewToysByName(
                 name="chew_toys_by_name__group_a",
-                description="Preferred chew toys by name - Group A",
+                description="Preferred chew toys by name (Group A)",
                 names=["Barbara", "Connie", "Graham"],
             )
+            .set_tier(3)
+            .set_tags(["toys", "name"])
         )
         self.add_coverpoint(
             ChewToysByName(
                 name="chew_toys_by_name__group_b",
-                description="Preferred chew toys by name - Group B",
+                description="Preferred chew toys by name (Group B)",
                 names=["Clive", "Derek", "Ethel"],
             )
+            .set_tier(2)
+            .set_tags(["toys", "name"])
         )
 
 
@@ -339,7 +348,7 @@ if __name__ == "__main__":
     ConsoleWriter(axes=False, goals=False, points=False).write(merged_reading)
 
     # Read all back from sql - note as the db is not removed this will
-    # acumulate each time this example is run. This will also include
+    # accumulate each time this example is run. This will also include
     # merged data as well as the individual runs. It is meant as an example
     # of how to use the command
     merged_reading_all = MergeReading(*sql_accessor.read_all())
@@ -350,5 +359,7 @@ if __name__ == "__main__":
     # print_tree() is a useful function to see the hierarchy of your coverage
     # You can call it from the top level covergroup, or from another covergroup
     # within your coverage tree.
+    print("\n-------------------------------------------------------")
+    print("Print coverage tree for cvg_a")
     cvg_a.print_tree()
     cvg_a.chew_toys.print_tree()

--- a/docs/index.md
+++ b/docs/index.md
@@ -170,7 +170,7 @@ Coverpoint and Covergroups may be filtered to allow coverage to run quicker. Thi
 
 | Function  | Description |
 |---|---|
-| `include_by_function()` | Enable coverpoints which match. Unmatched coverpoints will not change state |
+| `include_by_function()` | Enable coverpoints which match. Unmatched coverpoints will not have their active state changed, except this is the first filter to be applied, then any coverpoints which do not match are explicitly set to inactive, as the default state is active. |
 | `restrict_by_function()` | Restrict to coverpoints which match. Matched coverpoints will not change state. Unmatched will be disabled |
 | `exclude_by_function()` |  Disable coverpoints which match. Unmatched coverpoints will not change state |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -169,6 +169,7 @@ A sampler must be initialised with a reference to the top of the coverage hierar
 Coverpoint and Covergroups may be filtered to allow coverage to run quicker. This is useful when working on a small subset of coverage and you don't want to run everything, or for follow-up regressions to exclude already saturated coverpoints.
 
 | Function  | Description |
+|---|---|
 | `include_by_function()` | Enable coverpoints which match. Unmatched coverpoints will not change state |
 | `restrict_by_function()` | Restrict to coverpoints which match. Matched coverpoints will not change state. Unmatched will be disabled |
 | `exclude_by_function()` |  Disable coverpoints which match. Unmatched coverpoints will not change state |
@@ -180,6 +181,7 @@ Coverpoint and Covergroups may be filtered to allow coverage to run quicker. Thi
 Some helper functions have been provided to allow for easy use of common use-cases, but you are able to use the full capability of the filter function by providing your own match criteria.
 
 | Functions | Description |
+|---|---|
 | `*_by_name` | Provide a list of names to match against |
 | `*_by_tag` | Provide a list of tags to match against (either match all or some)|
 | `set_tier_level` | Restrict coverpoints to the requested tier level |

--- a/docs/index.md
+++ b/docs/index.md
@@ -173,8 +173,8 @@ Coverpoint and Covergroups may be filtered (to either be included or excluded) t
 | Parameter | Type | Description |
 | --- | --- | ---|
 | matcher | function | Function to match against coverpoints/covergroups |
-| match_state | bool | What the active state should be set to in the event of a match |
-| mismatch_state | bool | What the active state should be set to in the event it does not match. Can be 'None' if state should remain unchanged |
+| match_state | bool | What the active state should be set to in the event of a match. Set to 'None' if state should remain unchanged |
+| mismatch_state | bool | What the active state should be set to in the event it does not match. Set to 'None' if state should remain unchanged |
 
 Some helper functions have been provided to allow for easy use of common use-cases, but you are able to use the full capability of the filter function by providing your own match criteria.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -166,25 +166,33 @@ A sampler must be initialised with a reference to the top of the coverage hierar
 
 ## Filtering coverage
 
-Coverpoint and Covergroups may be filtered (to either be included or excluded) to allow coverage to run quicker. This is useful when working on a small subset of coverage and you don't want to run everything, or for follow-up regressions on the same build to exclude already saturated coverpoints.
+Coverpoint and Covergroups may be filtered to allow coverage to run quicker. This is useful when working on a small subset of coverage and you don't want to run everything, or for follow-up regressions to exclude already saturated coverpoints.
 
-`filter_by_function()`
+| Function  | Description |
+| `include_by_function()` | Enable coverpoints which match. Unmatched coverpoints will not change state |
+| `restrict_by_function()` | Restrict to coverpoints which match. Matched coverpoints will not change state. Unmatched will be disabled |
+| `exclude_by_function()` |  Disable coverpoints which match. Unmatched coverpoints will not change state |
 
 | Parameter | Type | Description |
 | --- | --- | ---|
-| matcher | function | Function to match against coverpoints/covergroups |
-| match_state | bool | What the active state should be set to in the event of a match. Set to 'None' if state should remain unchanged |
-| mismatch_state | bool | What the active state should be set to in the event it does not match. Set to 'None' if state should remain unchanged |
+| matcher | Callable | Function to match against coverpoints/covergroups |
 
 Some helper functions have been provided to allow for easy use of common use-cases, but you are able to use the full capability of the filter function by providing your own match criteria.
 
+| Functions | Description |
+| `*_by_name` | Provide a list of names to match against |
+| `*_by_tag` | Provide a list of tags to match against (either match all or some)|
+| `set_tier_level` | Restrict coverpoints to the requested tier level |
+
+The filter functions stack in the order they are provided. It is recommended that any `restrict_by_*` functions, and `set_tier_level` are called after any `include`/`exclude` functions.
+
 ```
-    # Only run branch related coverage, except for coverpoints related to if branch is taken
+    # Only run branch related coverage which are tier 1 or lower.
     cvg = MyBigCoverGroup(name="my_toplevel_covergroup", description="All of my coverage")
     cvg.include_by_name('branch_coverage')
-    cvg.exclude_by_name(['branch_taken'])
+    cvg.set_tier_level(1)
 ```
-These strings are hardcoded in the example above, but are intended to come from command line arguments/input files/etc.
+The strings/values are hardcoded in the example above, but are intended to come from command line arguments/input files/etc.
 
 
 ## Exporting coverage

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,8 +20,8 @@ Each new coverpoint should inherit from the Coverpoint class, and requires a 'na
 
 ``` Python
 class MyCoverpoint(Coverpoint):
-    def __init__(self, name: str, description: str, trigger=None):
-        super().__init__(name, description, trigger=None)
+    def __init__(self, name: str, description: str):
+        super().__init__(name, description)
 ```
 
 A `setup()` method is then required to create the axes and goals of the coverpoint. This function will only be called if the coverpoint is active. Next, you use `add_axis()` which requires a name, description and values.


### PR DESCRIPTION
Adding Tiers and Tags.

Tiers are similar to logging levels and allow you to specify critical coverage to nice-to-have coverage. Lower numbers are higher priority. These can then be filtered easily restrict to all tiers under a certain value. This is useful for CI/smaller regressions which may want to only include essential coverage.

Tags are strings* which can be applied to more easily filter out groups of coverpoints, instead of relying on names of covergroups/coverpoints. Functions are provided to easily include, restrict or exclude tags.

(*Tags may become enums in the future - but are strings for now)