### PR TITLE
Add pre_sample to covergroups

### DIFF
--- a/bucket/covergroup.py
+++ b/bucket/covergroup.py
@@ -305,21 +305,17 @@ class Covergroup(CoverBase):
             )
             cg.print_tree(indent + 1)
 
-    def pre_sample(self) -> bool:
-        # This function can be overridden by the user to stop the covergroup
-        # from passing on the trace data to its children
-        # By default it returns True
+    def should_sample(self) -> bool:
+        # This function can be optionally overridden by the user to stop the covergroup from
+        # passing on the trace data to its children. By default it returns True.
         return True
 
-    def sample(self, trace):
+    def _sample(self, trace):
         """Call sample for all children if active"""
 
-        if self.active and self.pre_sample():
-            for cp in self.coverpoints.values():
-                cp._sample(trace)
-
-            for cg in self.covergroups.values():
-                cg.sample(trace)
+        if self.active and self.should_sample():
+            for child in self.iter_children():
+                child._sample(trace)
 
     @validate_call
     def iter_children(self) -> Iterable[CoverBase]:

--- a/bucket/covergroup.py
+++ b/bucket/covergroup.py
@@ -305,9 +305,16 @@ class Covergroup(CoverBase):
             )
             cg.print_tree(indent + 1)
 
+    def pre_sample(self) -> bool:
+        # This function can be overridden by the user to stop the covergroup
+        # from passing on the trace data to its children
+        # By default it returns True
+        return True
+
     def sample(self, trace):
-        """Pass trace to sample on all sub-groups and coverpoints, if active"""
-        if self.active:
+        """Call sample for all children if active"""
+
+        if self.active and self.pre_sample():
             for cp in self.coverpoints.values():
                 cp._sample(trace)
 

--- a/bucket/sampler.py
+++ b/bucket/sampler.py
@@ -16,7 +16,7 @@ class Sampler:
     def sample(self, trace):
         """Go through the coverage tree and recursively call sample, passing in trace"""
         processed_trace = self.process_trace(trace)
-        self.coverage.sample(processed_trace)
+        self.coverage._sample(processed_trace)
 
     def process_trace(self, trace):
         """


### PR DESCRIPTION
 This allows the user to specify when a covergroup won't contain any coverpoints which should sample the trace data.

Eg. If a covergroup contains only branch instruction related covergroups/coverpoints, then the covergroup could prevent sampling being called for its children if the instruction is not of type branch. 