### PR TITLE
Add enable_other to Axes

### DIFF
--- a/bucket/coverpoint.py
+++ b/bucket/coverpoint.py
@@ -165,11 +165,17 @@ class Coverpoint(CoverBase):
         self.cvg_hits[bucket] += hits
 
     @validate_call
-    def add_axis(self, name: str, values: dict | list | set | tuple, description: str):
+    def add_axis(
+        self,
+        name: str,
+        values: dict | list | set | tuple,
+        description: str,
+        enable_other: None | bool | str = None,
+    ):
         """
         Add axis with values to process later
         """
-        self.axes.append(Axis(name, values, description))
+        self.axes.append(Axis(name, values, description, enable_other))
 
     @validate_call
     def add_goal(

--- a/example/cats.py
+++ b/example/cats.py
@@ -26,6 +26,12 @@ class TopCats(Covergroup):
                 description="A group of coverpoints about cat play toys",
             )
         )
+        self.add_coverpoint(
+            VIPNames(
+                name="VIPs",
+                description="Only important cat breeds",
+            )
+        )
 
     def should_sample(self, trace):
         """
@@ -224,5 +230,34 @@ class PlayToysByName(Coverpoint):
                 breed=trace["Breed"],
                 name=trace["Name"],
                 favourite_toy=trace["Play_toy"],
+            )
+            bucket.hit()
+
+
+class VIPNames(Coverpoint):
+    def __init__(self, name: str, description: str):
+        self.important_names = ["Clive", "Derek"]
+        super().__init__(name, description)
+
+    def setup(self, ctx):
+        self.add_axis(
+            name="breed",
+            values=ctx.pet_info.cat_breeds,
+            description="All known cat breeds",
+        )
+        # This axis uses the automatic 'other' to cover
+        # any values not explicitly provided
+        self.add_axis(
+            name="name",
+            values=self.important_names,
+            description="VIP names only",
+            enable_other="Plebs",
+        )
+
+    def sample(self, trace):
+        with self.bucket as bucket:
+            bucket.set_axes(
+                breed=trace["Breed"],
+                name=trace["Name"],
             )
             bucket.hit()


### PR DESCRIPTION
Axes now have an 'other' option if a sampled value doesn't match a specified one.
Alternatively the user may create an 'Other' axis value and use the sample method to safely process the data. 

This automates setting 'other', just as axes currently do with setting a ranged bucket if an unprocessed value is sampled.