### PR TITLE
Add file export/merge functionality in Viewer

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -632,7 +632,8 @@ ipcMain.handle('read-file', async (event, filePath) => {
     const buffer = await fsp.readFile(filePath);
     return Array.from(new Uint8Array(buffer));
   } catch (error) {
-    throw new Error(`Failed to read file: ${error.message}`);
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to read file: ${detail}`);
   }
 });
 
@@ -662,7 +663,8 @@ ipcMain.handle('save-export-file', async (event, payload) => {
     await fsp.writeFile(result.filePath, Buffer.from(bytes));
     return { canceled: false, path: result.filePath };
   } catch (error) {
-    throw new Error(`Failed to save export file: ${error.message}`);
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to save export file: ${detail}`);
   }
 });
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -636,6 +636,36 @@ ipcMain.handle('read-file', async (event, filePath) => {
   }
 });
 
+// Handle exporting files
+ipcMain.handle('save-export-file', async (event, payload) => {
+  try {
+    if (!mainWindow) {
+      return { canceled: true };
+    }
+
+    const format = payload?.format === 'json' ? 'json' : 'bktgz';
+    const defaultFileName = payload?.defaultFileName || `bucket_export.${format}`;
+    const filters = format === 'json'
+      ? [{ name: 'JSON Coverage', extensions: ['json'] }, { name: 'All Files', extensions: ['*'] }]
+      : [{ name: 'Bucket Archive', extensions: ['bktgz'] }, { name: 'All Files', extensions: ['*'] }];
+
+    const result = await dialog.showSaveDialog(mainWindow, {
+      defaultPath: defaultFileName,
+      filters,
+    });
+
+    if (result.canceled || !result.filePath) {
+      return { canceled: true };
+    }
+
+    const bytes = Array.isArray(payload?.bytes) ? payload.bytes : [];
+    await fsp.writeFile(result.filePath, Buffer.from(bytes));
+    return { canceled: false, path: result.filePath };
+  } catch (error) {
+    throw new Error(`Failed to save export file: ${error.message}`);
+  }
+});
+
 // Handle drag and drop
 ipcMain.handle('get-dropped-file', async (event, filePath) => {
   try {

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bucket-electron",
-  "version": "0.1.0",
+  "version": "2.2.0",
   "description": "Bucket Coverage Viewer - Mac App",
   "main": "main.js",
   "scripts": {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -10,6 +10,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('electronAPI', {
   openFileDialog: () => ipcRenderer.invoke('open-file-dialog'),
   readFile: (filePath) => ipcRenderer.invoke('read-file', filePath),
+  saveExportFile: (payload) => ipcRenderer.invoke('save-export-file', payload),
   getDroppedFiles: (filePaths) => ipcRenderer.invoke('get-dropped-files', filePaths),
   onFilesOpened: (callback) => {
     // Remove any existing listeners to avoid duplicates

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -11,7 +11,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   openFileDialog: () => ipcRenderer.invoke('open-file-dialog'),
   readFile: (filePath) => ipcRenderer.invoke('read-file', filePath),
   saveExportFile: (payload) => ipcRenderer.invoke('save-export-file', payload),
-  getDroppedFiles: (filePaths) => ipcRenderer.invoke('get-dropped-files', filePaths),
+  getDroppedFiles: (filePaths) => ipcRenderer.invoke('get-dropped-file', filePaths),
   onFilesOpened: (callback) => {
     // Remove any existing listeners to avoid duplicates
     ipcRenderer.removeAllListeners('files-opened');

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bucket"
-version = "2.1.3"
+version = "2.2.0"
 description = "Functional coverage written in Python"
 authors = [
     {name = "Stuart Alldred", email = "stuartalldred@gmail.com"},

--- a/viewer/src/features/Dashboard/index.tsx
+++ b/viewer/src/features/Dashboard/index.tsx
@@ -8,39 +8,62 @@ import Theme from "@/providers/Theme";
 import type { FloatButtonProps, TreeDataNode } from "antd";
 import {
     Breadcrumb,
+    Button,
+    Checkbox,
     ConfigProvider,
-    Layout,
-    Segmented,
     Flex,
     FloatButton,
-    Button,
+    Input,
+    Layout,
+    Modal,
+    Segmented,
+    Select,
+    Switch,
+    Table,
     Typography,
 } from "antd";
-import { BgColorsOutlined, FileAddOutlined, ClearOutlined, FolderOpenOutlined } from "@ant-design/icons";
+import {
+    BgColorsOutlined,
+    ClearOutlined,
+    EditOutlined,
+    ExportOutlined,
+    FileAddOutlined,
+    PieChartOutlined,
+    ReloadOutlined,
+    TableOutlined,
+} from "@ant-design/icons";
 import Tree, { TreeKey, TreeNode } from "./lib/tree";
-
 import Sider from "./components/Sider";
 import EmptyState from "./components/EmptyState";
 import { antTheme, view } from "./theme";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { BreadcrumbItemType } from "antd/lib/breadcrumb/Breadcrumb";
-import { TableOutlined, PieChartOutlined } from "@ant-design/icons";
 import { PointGrid, PointSummaryGrid } from "./lib/coveragegrid";
 import { PointPivotView } from "./lib/pivottable";
 import { CoverageDonut } from "./lib/coveragedonut";
 import { hexToRgba } from "@/utils/colors";
+import type { CoverageRecord, CoverageSourceRef, ExportFormat } from "@/types/coverageSession";
+import { getDefaultExportFileName } from "@/services/exportSaver";
+
 const { Header, Content } = Layout;
+
+type RecordTableRow = {
+    id: string;
+    key: string;
+    label: string;
+    sourceLabel: string;
+    sourceKind: string;
+    recordIndex: number;
+    isLoaded: boolean;
+};
 
 const ColorModeToggleButton = (props: FloatButtonProps) => {
     return (
         <Theme.Consumer>
             {(context) => {
                 const onClick = () => {
-                    // Roll around the defined themes, with one extra to return to auto
                     const currentIdx =
-                        themes.findIndex(
-                            (v) => v.name === context.theme.name,
-                        ) ?? 0;
+                        themes.findIndex((v) => v.name === context.theme.name) ?? 0;
                     const nextIdx = (currentIdx + 1) % (themes.length + 1);
                     context.setTheme(themes[nextIdx] ?? null);
                 };
@@ -57,27 +80,19 @@ const ColorModeToggleButton = (props: FloatButtonProps) => {
     );
 };
 
-type breadCrumbMenuProps = {
-    /** The node we're creating a menu for */
+type BreadCrumbMenuProps = {
     pathNode: TreeDataNode;
-    /** The nodes we want to be in the menu */
     menuNodes: TreeDataNode[];
-    /** Callback when a menu node is selected */
     onSelect: (selectedKeys: TreeKey[]) => void;
-    /** Theme object */
     theme: ThemeType;
 };
-/**
- * Factory for bread crumb menus (dropdowns on breadcrumb)
- * @param breadCrumbMenuProps
- * @returns a bread crumb menu
- */
+
 function getBreadCrumbMenu({
     pathNode,
     menuNodes,
     onSelect,
     theme,
-}: breadCrumbMenuProps) {
+}: BreadCrumbMenuProps) {
     let menu: BreadcrumbItemType["menu"] | undefined = undefined;
     if (menuNodes.length > 1 || pathNode !== menuNodes[0]) {
         menu = {
@@ -94,29 +109,22 @@ function getBreadCrumbMenu({
     return menu;
 }
 
-type breadCrumbItemsProps = {
-    /** The tree of nodes */
+type BreadCrumbItemsProps = {
     tree: Tree;
-    /** The ancestor path to the selected node */
     selectedTreeKeys: TreeKey[];
-    /** Callback when a node is selected */
     onSelect: (newSelectedKeys: TreeKey[]) => void;
-    /** Theme object */
     theme: ThemeType;
 };
-/**
- * Create bread crumb items from the tree data
- */
+
 function getBreadCrumbItems({
     tree,
     selectedTreeKeys,
     onSelect,
     theme,
-}: breadCrumbItemsProps): BreadcrumbItemType[] {
+}: BreadCrumbItemsProps): BreadcrumbItemType[] {
     const pathNodes = tree.getAncestorsByKey(selectedTreeKeys[0]);
-
     const breadCrumbItems: BreadcrumbItemType[] = [];
-    // Create the root
+
     {
         const pathNode = { title: "Root", key: "_ROOT" };
         breadCrumbItems.push({
@@ -127,7 +135,6 @@ function getBreadCrumbItems({
         });
     }
 
-    // Create the nodes down to the selected node
     let menuNodes: TreeNode[] = tree.getRoots();
     for (const pathNode of pathNodes) {
         breadCrumbItems.push({
@@ -139,8 +146,6 @@ function getBreadCrumbItems({
         menuNodes = pathNode.children ?? [];
     }
 
-    // Create an extra node if we're not a leaf node to add an
-    // extra dropdown to select a leaf
     if (menuNodes.length) {
         const pathNode = { title: "...", key: "_CHILD" };
         breadCrumbItems.push({
@@ -153,26 +158,125 @@ function getBreadCrumbItems({
     return breadCrumbItems;
 }
 
+function getReadoutLabel(record: CoverageRecord, source: CoverageSourceRef | undefined): string {
+    const sourceLabel = source?.label ?? "Unknown Source";
+    let readoutSource = "";
+    try {
+        const sourceValue = record.readout.get_source();
+        const sourceKeyValue = record.readout.get_source_key();
+        if (sourceValue && sourceKeyValue) {
+            readoutSource = `${sourceValue}[${sourceKeyValue}]`;
+        } else if (sourceValue) {
+            readoutSource = sourceValue;
+        } else if (sourceKeyValue) {
+            readoutSource = `[${sourceKeyValue}]`;
+        }
+    } catch {
+        readoutSource = "";
+    }
+    const prefix = readoutSource ? `${readoutSource} - ` : "";
+    return `${prefix}${sourceLabel} (record ${record.sourceRecordIndex})`;
+}
+
+function stripExportExtension(fileName: string): string {
+    return fileName.replace(/\.(bktgz|json)$/i, "");
+}
+
 export type DashboardProps = {
     tree: Tree;
+    records: CoverageRecord[];
+    sources: CoverageSourceRef[];
     onOpenFile?: () => void | Promise<void>;
     onClearCoverage?: () => void;
+    onSetLoadedRecords?: (loadedRecordIds: string[]) => void;
+    onMergeRecords?: (recordIds: string[]) => Promise<void> | void;
+    onRefreshRecords?: () => Promise<void> | void;
+    onExportRecords?: (options: {
+        recordIds: string[];
+        format: ExportFormat;
+        mergeBeforeExport: boolean;
+        fileBaseName?: string;
+    }) => Promise<void> | void;
     isDragging?: boolean;
 };
 
-export default function Dashboard({ tree, onOpenFile, onClearCoverage, isDragging = false }: DashboardProps) {
+export default function Dashboard({
+    tree,
+    records,
+    sources,
+    onOpenFile,
+    onClearCoverage,
+    onSetLoadedRecords,
+    onMergeRecords,
+    onRefreshRecords,
+    onExportRecords,
+    isDragging = false,
+}: DashboardProps) {
+    const isElectronRuntime = typeof window !== "undefined" && window.electronAPI !== undefined;
+
     const [selectedTreeKeys, setSelectedTreeKeys] = useState<TreeKey[]>([]);
     const [expandedTreeKeys, setExpandedTreeKeys] = useState<TreeKey[]>([]);
     const [autoExpandTreeParent, setAutoExpandTreeParent] = useState(true);
     const [treeKeyContentKey, setTreeKeyContentKey] = useState(
         {} as { [key: TreeKey]: string | number },
     );
-    const [summaryViewMode, setSummaryViewMode] = useState<'table' | 'donut'>('table');
+    const [summaryViewMode, setSummaryViewMode] = useState<"table" | "donut">("table");
+    const [editModalOpen, setEditModalOpen] = useState(false);
+    const [editLoadedById, setEditLoadedById] = useState<Record<string, boolean>>({});
+    const [mergeSelectedIds, setMergeSelectedIds] = useState<string[]>([]);
+    const [editActionBusy, setEditActionBusy] = useState(false);
+    const [exportModalOpen, setExportModalOpen] = useState(false);
+    const [exportSelectedIds, setExportSelectedIds] = useState<string[]>([]);
+    const [exportFormat, setExportFormat] = useState<ExportFormat>("bktgz");
+    const [exportMergeBeforeWrite, setExportMergeBeforeWrite] = useState(false);
+    const [exportFileName, setExportFileName] = useState("");
+    const [exportBusy, setExportBusy] = useState(false);
 
-    // Check if tree is empty (no coverage loaded)
     const isEmpty = tree.getRoots().length === 0;
 
-    // Reset selected keys when tree becomes empty or selected key no longer exists (e.g., after clearing coverage)
+    const sourceById = useMemo(() => {
+        return new Map(sources.map((source) => [source.id, source]));
+    }, [sources]);
+
+    const recordRows = useMemo<RecordTableRow[]>(() => {
+        return records.map((record) => {
+            const source = sourceById.get(record.sourceRef);
+            return {
+                id: record.id,
+                key: record.id,
+                label: getReadoutLabel(record, source),
+                sourceLabel: source?.label ?? "Unknown",
+                sourceKind: source?.kind ?? "unknown",
+                recordIndex: record.sourceRecordIndex,
+                isLoaded: record.isLoaded,
+            };
+        });
+    }, [records, sourceById]);
+
+    const loadedRecordRows = useMemo(
+        () => recordRows.filter((record) => record.isLoaded),
+        [recordRows],
+    );
+
+    useEffect(() => {
+        if (!editModalOpen) {
+            return;
+        }
+        setEditLoadedById(
+            Object.fromEntries(records.map((record) => [record.id, record.isLoaded])),
+        );
+    }, [records, editModalOpen]);
+
+    useEffect(() => {
+        if (!exportModalOpen) {
+            return;
+        }
+        setExportSelectedIds(loadedRecordRows.map((record) => record.id));
+        setExportFormat("bktgz");
+        setExportMergeBeforeWrite(false);
+        setExportFileName(stripExportExtension(getDefaultExportFileName("bktgz", false)));
+    }, [exportModalOpen, loadedRecordRows]);
+
     useEffect(() => {
         if (isEmpty) {
             if (selectedTreeKeys.length > 0) {
@@ -181,17 +285,15 @@ export default function Dashboard({ tree, onOpenFile, onClearCoverage, isDraggin
                 setTreeKeyContentKey({});
             }
         } else if (selectedTreeKeys.length > 0) {
-            // Check if the selected key still exists in the tree
             const viewKey = selectedTreeKeys[0];
             if (viewKey !== Tree.ROOT && !tree.getNodeByKey(viewKey)) {
-                // Selected key no longer exists, reset to root
                 setSelectedTreeKeys([]);
                 setExpandedTreeKeys([]);
             }
         }
     }, [tree, selectedTreeKeys, isEmpty]);
 
-    const onSelect = (newSelectedKeys: TreeKey[]) => {
+    const onSelect = useCallback((newSelectedKeys: TreeKey[]) => {
         const newExpandedKeys = new Set<TreeKey>(expandedTreeKeys);
         for (const newSelectedKey of newSelectedKeys) {
             for (const ancestor of tree.getAncestorsByKey(newSelectedKey)) {
@@ -200,14 +302,16 @@ export default function Dashboard({ tree, onOpenFile, onClearCoverage, isDraggin
         }
         setExpandedTreeKeys(Array.from(newExpandedKeys));
         setSelectedTreeKeys(newSelectedKeys);
-        // We're manually managing the ancestor expansion
         setAutoExpandTreeParent(false);
-    };
+    }, [expandedTreeKeys, tree]);
 
     const viewKey = selectedTreeKeys[0] ?? Tree.ROOT;
     const contentViews = tree.getViewsByKey(viewKey);
     const defaultView = contentViews[0];
     const currentContentKey = treeKeyContentKey[viewKey] ?? defaultView.value;
+    const showContentViewSelector =
+        contentViews.length > 1
+        || (contentViews.length === 1 && contentViews[0].value !== "Summary");
 
     const onViewChange = (newView: string | number) => {
         setTreeKeyContentKey({
@@ -216,21 +320,17 @@ export default function Dashboard({ tree, onOpenFile, onClearCoverage, isDraggin
         });
     };
 
-
-    // Determine logo path based on the runtime environment:
-    // - Electron production: Use app:// protocol (custom protocol registered in main.js)
-    // - Browser with file://: Use relative path (when opening HTML directly)
-    // - Browser with http://: Use Vite's BASE_URL (development server)
-    const isElectronProduction = typeof window !== 'undefined' && window.location.protocol === 'app:';
-    const isFileProtocol = typeof window !== 'undefined' && window.location.protocol === 'file:';
+    const isElectronProduction =
+        typeof window !== "undefined" && window.location.protocol === "app:";
+    const isFileProtocol =
+        typeof window !== "undefined" && window.location.protocol === "file:";
     const logoSrc = isElectronProduction
-        ? 'app://logo.svg'
+        ? "app://logo.svg"
         : isFileProtocol
-        ? './logo.svg'
-        : `${import.meta.env.BASE_URL}logo.svg`;
-    // Get source and source_key from the currently selected node's readout
+          ? "./logo.svg"
+          : `${import.meta.env.BASE_URL}logo.svg`;
+
     const sourceInfo = useMemo(() => {
-        // Don't show source info when at root level
         if (viewKey === Tree.ROOT) {
             return { source: null, source_key: null };
         }
@@ -243,8 +343,7 @@ export default function Dashboard({ tree, onOpenFile, onClearCoverage, isDraggin
                     source: readout.get_source?.() ?? null,
                     source_key: readout.get_source_key?.() ?? null,
                 };
-            } catch (error) {
-                // Fallback if methods don't exist (old readout format)
+            } catch {
                 return { source: null, source_key: null };
             }
         }
@@ -252,14 +351,12 @@ export default function Dashboard({ tree, onOpenFile, onClearCoverage, isDraggin
     }, [tree, viewKey]);
 
     const selectedViewContent = useMemo(() => {
-        // Show empty state if no coverage is loaded
         if (isEmpty) {
             return <EmptyState logoSrc={logoSrc} onOpenFile={onOpenFile} />;
         }
 
         const currentNode = tree.getNodeByKey(viewKey);
         if (!currentNode) {
-            // Node doesn't exist (e.g., after clearing coverage), show empty state
             return null;
         }
 
@@ -267,7 +364,7 @@ export default function Dashboard({ tree, onOpenFile, onClearCoverage, isDraggin
             case "Pivot":
                 return <PointPivotView node={currentNode} />;
             case "Summary":
-                if (summaryViewMode === 'donut') {
+                if (summaryViewMode === "donut") {
                     return (
                         <CoverageDonut
                             tree={tree}
@@ -288,127 +385,386 @@ export default function Dashboard({ tree, onOpenFile, onClearCoverage, isDraggin
             default:
                 throw new Error("Invalid view!?");
         }
-    }, [viewKey, currentContentKey, tree, isEmpty, onOpenFile, logoSrc, summaryViewMode]);
+    }, [viewKey, currentContentKey, tree, isEmpty, onOpenFile, logoSrc, summaryViewMode, onSelect]);
+
+    const applyLoadedEdits = () => {
+        if (!onSetLoadedRecords) {
+            return;
+        }
+        const loadedIds = Object.entries(editLoadedById)
+            .filter(([, loaded]) => loaded)
+            .map(([id]) => id);
+        onSetLoadedRecords(loadedIds);
+        setEditModalOpen(false);
+    };
+
+    const runMergeSelected = async () => {
+        if (!onMergeRecords || mergeSelectedIds.length < 2) {
+            return;
+        }
+        setEditActionBusy(true);
+        try {
+            await onMergeRecords(mergeSelectedIds);
+            setMergeSelectedIds([]);
+        } finally {
+            setEditActionBusy(false);
+        }
+    };
+
+    const runExport = async () => {
+        if (!onExportRecords || exportSelectedIds.length === 0) {
+            return;
+        }
+        setExportBusy(true);
+        try {
+            await onExportRecords({
+                recordIds: exportSelectedIds,
+                format: exportFormat,
+                mergeBeforeExport: exportMergeBeforeWrite,
+                fileBaseName: exportFileName.trim() || undefined,
+            });
+            setExportModalOpen(false);
+        } finally {
+            setExportBusy(false);
+        }
+    };
 
     return (
         <ConfigProvider theme={antTheme}>
             <Theme.Consumer>
                 {({ theme: themeContext }) => {
-                    const dragStyle = isDragging ? {
-                        border: '3px dashed',
-                        borderColor: themeContext.theme.colors.accentbg.value,
-                        backgroundColor: hexToRgba(themeContext.theme.colors.highlightbg.value, 0.25),
-                        transition: 'all 0.2s ease-in-out',
-                    } : {};
+                    const dragStyle = isDragging
+                        ? {
+                              border: "3px dashed",
+                              borderColor: themeContext.theme.colors.accentbg.value,
+                              backgroundColor: hexToRgba(
+                                  themeContext.theme.colors.highlightbg.value,
+                                  0.25,
+                              ),
+                              transition: "all 0.2s ease-in-out",
+                          }
+                        : {};
                     return (
                         <Layout
                             {...view.props}
                             style={{
                                 ...view.props.style,
                                 ...dragStyle,
-                            }}
-                        >
-                {!isEmpty && (
-                    <Sider
-                        tree={tree}
-                        selectedTreeKeys={selectedTreeKeys}
-                        setSelectedTreeKeys={onSelect}
-                        expandedTreeKeys={expandedTreeKeys}
-                        setExpandedTreeKeys={setExpandedTreeKeys}
-                        autoExpandTreeParent={autoExpandTreeParent}
-                        setAutoExpandTreeParent={setAutoExpandTreeParent}></Sider>
-                )}
-                <Layout {...view.body.props}>
-                    {!isEmpty && (
-                        <Header {...view.body.header.props}>
-                            <Flex {...view.body.header.flex.props}>
-                                <Theme.Consumer>
-                                    {/* The breadcrumb menu is placed outside of the main DOM tree
-                                        so we need to pass through the theme class */}
-                                    {({ theme }) => (
-                                        <>
-                                            <Breadcrumb
-                                                {...view.body.header.flex.breadcrumb
-                                                    .props}
-                                                items={getBreadCrumbItems({
-                                                    tree,
-                                                    selectedTreeKeys,
-                                                    onSelect,
-                                                    theme,
-                                                })}></Breadcrumb>
-                                            {(sourceInfo.source || sourceInfo.source_key) && (
-                                                <Flex gap="small" style={{ marginLeft: '16px' }}>
-                                                    <span style={{ color: theme.theme.colors.primarytxt.value }}>
-                                                        {sourceInfo.source && sourceInfo.source_key
-                                                            ? `${sourceInfo.source}[${sourceInfo.source_key}]`
-                                                            : sourceInfo.source
-                                                            ? sourceInfo.source
-                                                            : `[${sourceInfo.source_key}]`}
-                                                    </span>
+                            }}>
+                            {!isEmpty && (
+                                <Sider
+                                    tree={tree}
+                                    selectedTreeKeys={selectedTreeKeys}
+                                    setSelectedTreeKeys={onSelect}
+                                    expandedTreeKeys={expandedTreeKeys}
+                                    setExpandedTreeKeys={setExpandedTreeKeys}
+                                    autoExpandTreeParent={autoExpandTreeParent}
+                                    setAutoExpandTreeParent={setAutoExpandTreeParent}></Sider>
+                            )}
+                            <Layout {...view.body.props}>
+                                {!isEmpty && (
+                                    <Header {...view.body.header.props}>
+                                        <Flex {...view.body.header.flex.props}>
+                                            <Theme.Consumer>
+                                                {({ theme }) => (
+                                                    <>
+                                                        <Breadcrumb
+                                                            {...view.body.header.flex.breadcrumb.props}
+                                                            items={getBreadCrumbItems({
+                                                                tree,
+                                                                selectedTreeKeys,
+                                                                onSelect,
+                                                                theme,
+                                                            })}></Breadcrumb>
+                                                        {(sourceInfo.source || sourceInfo.source_key) && (
+                                                            <Flex
+                                                                gap="small"
+                                                                style={{ marginLeft: "16px" }}>
+                                                                <span
+                                                                    style={{
+                                                                        color: theme.theme.colors
+                                                                            .primarytxt.value,
+                                                                    }}>
+                                                                    {sourceInfo.source &&
+                                                                    sourceInfo.source_key
+                                                                        ? `${sourceInfo.source}[${sourceInfo.source_key}]`
+                                                                        : sourceInfo.source
+                                                                          ? sourceInfo.source
+                                                                          : `[${sourceInfo.source_key}]`}
+                                                                </span>
+                                                            </Flex>
+                                                        )}
+                                                    </>
+                                                )}
+                                            </Theme.Consumer>
+                                            <Flex gap="small" align="center">
+                                                {showContentViewSelector && (
+                                                    <Segmented
+                                                        {...view.body.header.flex.segmented.props}
+                                                        options={contentViews}
+                                                        value={currentContentKey}
+                                                        onChange={onViewChange}
+                                                    />
+                                                )}
+                                                {currentContentKey === "Summary" && (
+                                                    <Flex
+                                                        align="center"
+                                                        gap="small"
+                                                        style={{
+                                                            border: `1px solid ${themeContext.theme.colors.lowlightbg.value}`,
+                                                            borderRadius: 8,
+                                                            padding: "2px 6px",
+                                                            backgroundColor:
+                                                                themeContext.theme.colors.secondarybg
+                                                                    .value,
+                                                        }}>
+                                                        <Typography.Text
+                                                            style={{
+                                                                color: themeContext.theme.colors
+                                                                    .desaturatedtxt.value,
+                                                                fontSize: 12,
+                                                                letterSpacing: 0.3,
+                                                            }}>
+                                                            View
+                                                        </Typography.Text>
+                                                        <Segmented
+                                                            size="small"
+                                                            options={[
+                                                                {
+                                                                    value: "table",
+                                                                    icon: <TableOutlined />,
+                                                                    label: "Table",
+                                                                    title: "View coverage as a table",
+                                                                },
+                                                                {
+                                                                    value: "donut",
+                                                                    icon: <PieChartOutlined />,
+                                                                    label: "Donut",
+                                                                    title:
+                                                                        "View coverage as a donut chart",
+                                                                },
+                                                            ]}
+                                                            value={summaryViewMode}
+                                                            onChange={(value) =>
+                                                                setSummaryViewMode(
+                                                                    value as "table" | "donut",
+                                                                )
+                                                            }
+                                                        />
+                                                    </Flex>
+                                                )}
+
+                                                {(showContentViewSelector
+                                                    || currentContentKey === "Summary")
+                                                && (
+                                                    <div
+                                                        style={{
+                                                            width: 1,
+                                                            height: 24,
+                                                            backgroundColor:
+                                                                themeContext.theme.colors.lowlightbg
+                                                                    .value,
+                                                            margin: "0 2px",
+                                                        }}
+                                                    />
+                                                )}
+
+                                                <Flex gap="small" align="center">
+                                                    {onOpenFile && (
+                                                        <Button
+                                                            icon={<FileAddOutlined />}
+                                                            onClick={onOpenFile}
+                                                            size="small"
+                                                            type="primary">
+                                                            Load
+                                                        </Button>
+                                                    )}
+                                                    {onSetLoadedRecords && (
+                                                        <Button
+                                                            icon={<EditOutlined />}
+                                                            onClick={() => {
+                                                                setEditModalOpen(true);
+                                                                setMergeSelectedIds([]);
+                                                            }}
+                                                            size="small">
+                                                            Edit
+                                                        </Button>
+                                                    )}
+                                                    {onRefreshRecords && isElectronRuntime && (
+                                                        <Button
+                                                            icon={<ReloadOutlined />}
+                                                            onClick={() => onRefreshRecords()}
+                                                            size="small">
+                                                            Refresh
+                                                        </Button>
+                                                    )}
+                                                    {onExportRecords && (
+                                                        <Button
+                                                            icon={<ExportOutlined />}
+                                                            onClick={() => setExportModalOpen(true)}
+                                                            size="small">
+                                                            Export
+                                                        </Button>
+                                                    )}
+                                                    {onClearCoverage && (
+                                                        <Button
+                                                            icon={<ClearOutlined />}
+                                                            onClick={onClearCoverage}
+                                                            size="small"
+                                                            danger>
+                                                            Clear
+                                                        </Button>
+                                                    )}
                                                 </Flex>
-                                            )}
-                                        </>
-                                    )}
-                                </Theme.Consumer>
-                                <Flex gap="small" align="center">
-                                    <Segmented
-                                        {...view.body.header.flex.segmented.props}
-                                        options={contentViews}
-                                        value={currentContentKey}
-                                        onChange={onViewChange}
-                                    />
-                                    {currentContentKey === "Summary" && (
-                                        <Segmented
-                                            options={[
-                                                {
-                                                    value: 'table',
-                                                    icon: <TableOutlined />,
-                                                    label: 'Table',
-                                                    title: 'View coverage as a table',
-                                                },
-                                                {
-                                                    value: 'donut',
-                                                    icon: <PieChartOutlined />,
-                                                    label: 'Donut',
-                                                    title: 'View coverage as a donut chart',
-                                                },
-                                            ]}
-                                            value={summaryViewMode}
-                                            onChange={(value) => setSummaryViewMode(value as 'table' | 'donut')}
-                                        />
-                                    )}
-                                    {onOpenFile && (
-                                        <Button
-                                            icon={<FileAddOutlined />}
-                                            onClick={onOpenFile}
-                                            size="small"
-                                            type="primary"
-                                        >
-                                            Load
-                                        </Button>
-                                    )}
-                                    {onClearCoverage && (
-                                        <Button
-                                            icon={<ClearOutlined />}
-                                            onClick={onClearCoverage}
-                                            size="small"
-                                            danger
-                                        >
-                                            Clear
-                                        </Button>
-                                    )}
-                                </Flex>
-                            </Flex>
-                        </Header>
-                    )}
-                    <Content {...view.body.content.props}>
-                        {selectedViewContent}
-                    </Content>
-                </Layout>
+                                            </Flex>
+                                        </Flex>
+                                    </Header>
+                                )}
+                                <Content {...view.body.content.props}>{selectedViewContent}</Content>
+                            </Layout>
                         </Layout>
                     );
                 }}
             </Theme.Consumer>
+
+            <Modal
+                title="Edit Records"
+                open={editModalOpen}
+                onCancel={() => setEditModalOpen(false)}
+                width={900}
+                footer={[
+                    <Button key="cancel" onClick={() => setEditModalOpen(false)}>
+                        Cancel
+                    </Button>,
+                    <Button
+                        key="merge"
+                        onClick={() => void runMergeSelected()}
+                        disabled={mergeSelectedIds.length < 2}
+                        loading={editActionBusy}>
+                        Merge Selected
+                    </Button>,
+                    <Button key="apply" type="primary" onClick={applyLoadedEdits}>
+                        Apply
+                    </Button>,
+                ]}>
+                <Table<RecordTableRow>
+                    size="small"
+                    pagination={false}
+                    rowKey="id"
+                    dataSource={recordRows}
+                    rowSelection={{
+                        selectedRowKeys: mergeSelectedIds,
+                        onChange: (selectedKeys) =>
+                            setMergeSelectedIds(selectedKeys as string[]),
+                    }}
+                    columns={[
+                        {
+                            title: "Loaded",
+                            width: 90,
+                            render: (_value, row) => (
+                                <Switch
+                                    checked={editLoadedById[row.id] ?? row.isLoaded}
+                                    onChange={(checked) =>
+                                        setEditLoadedById((current) => ({
+                                            ...current,
+                                            [row.id]: checked,
+                                        }))
+                                    }
+                                />
+                            ),
+                        },
+                        {
+                            title: "Record",
+                            dataIndex: "label",
+                        },
+                        {
+                            title: "Source",
+                            dataIndex: "sourceLabel",
+                            width: 190,
+                        },
+                        {
+                            title: "Kind",
+                            dataIndex: "sourceKind",
+                            width: 130,
+                        },
+                        {
+                            title: "Index",
+                            dataIndex: "recordIndex",
+                            width: 90,
+                        },
+                    ]}
+                />
+                <Typography.Text type="secondary" style={{ marginTop: 12, display: "block" }}>
+                    Selected for merge: {mergeSelectedIds.length}
+                </Typography.Text>
+            </Modal>
+
+            <Modal
+                title="Export Records"
+                open={exportModalOpen}
+                onCancel={() => setExportModalOpen(false)}
+                onOk={() => void runExport()}
+                okText="Export"
+                confirmLoading={exportBusy}
+                okButtonProps={{ disabled: exportSelectedIds.length === 0 }}>
+                <Flex vertical gap="middle">
+                    <div>
+                        <Typography.Text strong>Records</Typography.Text>
+                        <div style={{ marginTop: 8, maxHeight: 220, overflowY: "auto" }}>
+                            <Checkbox.Group
+                                style={{
+                                    display: "flex",
+                                    flexDirection: "column",
+                                    gap: 8,
+                                }}
+                                value={exportSelectedIds}
+                                onChange={(values) =>
+                                    setExportSelectedIds(values.map((value) => String(value)))
+                                }>
+                                {loadedRecordRows.map((record) => (
+                                    <Checkbox key={record.id} value={record.id}>
+                                        {record.label}
+                                    </Checkbox>
+                                ))}
+                            </Checkbox.Group>
+                        </div>
+                    </div>
+
+                    <div>
+                        <Typography.Text strong>Format</Typography.Text>
+                        <Select
+                            value={exportFormat}
+                            onChange={(value) => setExportFormat(value as ExportFormat)}
+                            style={{ width: 200, marginLeft: 12 }}
+                            options={[
+                                { value: "bktgz", label: ".bktgz (Bucket Archive)" },
+                                { value: "json", label: ".json" },
+                            ]}
+                        />
+                    </div>
+
+                    <div>
+                        <Typography.Text strong>Merge Before Writing</Typography.Text>
+                        <Switch
+                            style={{ marginLeft: 12 }}
+                            checked={exportMergeBeforeWrite}
+                            onChange={setExportMergeBeforeWrite}
+                        />
+                    </div>
+
+                    <div>
+                        <Typography.Text strong>File Name</Typography.Text>
+                        <Input
+                            style={{ marginTop: 8 }}
+                            value={exportFileName}
+                            onChange={(event) => setExportFileName(event.target.value)}
+                            placeholder="coverage_export"
+                            addonAfter={exportFormat === "json" ? ".json" : ".bktgz"}
+                        />
+                    </div>
+                </Flex>
+            </Modal>
+
             <ColorModeToggleButton {...view.float.theme.props} />
         </ConfigProvider>
     );

--- a/viewer/src/features/Dashboard/index.tsx
+++ b/viewer/src/features/Dashboard/index.tsx
@@ -424,6 +424,8 @@ export default function Dashboard({
                 fileBaseName: exportFileName.trim() || undefined,
             });
             setExportModalOpen(false);
+        } catch {
+            // Failure: caller (e.g. useFileLoader) shows notification; keep modal open to retry
         } finally {
             setExportBusy(false);
         }

--- a/viewer/src/features/Dashboard/theme.tsx
+++ b/viewer/src/features/Dashboard/theme.tsx
@@ -187,6 +187,18 @@ export const antTheme: ThemeConfig = (() => {
                 itemSelectedBg: cl.highlightbg.toString(),
                 trackPadding: 0,
             },
+            Button: {
+                // Keep default (non-primary/non-danger) buttons readable in dark themes.
+                defaultBg: cl.tertiarybg.toString(),
+                defaultColor: cl.saturatedtxt.toString(),
+                defaultBorderColor: cl.lowlightbg.toString(),
+                defaultHoverBg: cl.highlightbg.toString(),
+                defaultHoverColor: cl.saturatedtxt.toString(),
+                defaultHoverBorderColor: cl.highlightbg.toString(),
+                defaultActiveBg: cl.lowlightbg.toString(),
+                defaultActiveColor: cl.saturatedtxt.toString(),
+                defaultActiveBorderColor: cl.lowlightbg.toString(),
+            },
             FloatButton: {
                 colorBgElevated: cl.highlightbg.toString(),
             },

--- a/viewer/src/hooks/useFileLoader.ts
+++ b/viewer/src/hooks/useFileLoader.ts
@@ -522,6 +522,7 @@ export function useFileLoader() {
                 description: errorMessage,
                 duration: 5,
             });
+            throw err;
         }
     };
 

--- a/viewer/src/hooks/useFileLoader.ts
+++ b/viewer/src/hooks/useFileLoader.ts
@@ -3,58 +3,215 @@
  * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
  */
 
-import { useEffect, useRef, useState } from "react";
-import { notification, Modal } from "antd";
-import CoverageTree from "@/features/Dashboard/lib/coveragetree";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Modal, notification } from "antd";
+import CoverageTree from "../features/Dashboard/lib/coveragetree";
 import {
     isElectron,
-    loadFileFromBytes,
-    loadFileFromFileObject,
-    loadFileFromFileHandle,
+    loadReadoutsFromElectronPath,
+    loadReadoutsFromFileHandle,
+    loadReadoutsFromFileObject,
     openElectronFileDialog,
 } from "@/services/fileLoader";
+import type {
+    CoverageRecord,
+    CoverageSession,
+    CoverageSourceRef,
+    ExportFormat,
+} from "@/types/coverageSession";
+import { mergeReadoutsStrict } from "@/services/readoutUtils";
+import { serializeReadouts } from "@/services/exportSerializers";
+import { getDefaultExportFileName, saveExportBytes } from "@/services/exportSaver";
 
-/**
- * Get the default empty tree
- */
-function getDefaultTree(): CoverageTree {
-    return new CoverageTree([]);
+type FilePickerWindow = Window & {
+    showOpenFilePicker?: (options?: {
+        multiple?: boolean;
+        types?: Array<{
+            description?: string;
+            accept: Record<string, string[]>;
+        }>;
+    }) => Promise<FileSystemFileHandle[]>;
+};
+
+type RefreshWarning = {
+    sourceLabel: string;
+    detail: string;
+};
+
+type SourceLoadPayload = {
+    readouts: Readout[];
+    source: Omit<CoverageSourceRef, "id">;
+};
+
+type LoadMode = "replace" | "append";
+
+function getDefaultSession(): CoverageSession {
+    return {
+        records: [],
+        sources: [],
+        loadedRecordIds: [],
+    };
 }
 
-/**
- * Custom hook for managing file loading and tree state
- */
+function isNoCoverageError(errorMessage: string): boolean {
+    return errorMessage.toLowerCase().includes("no coverage data");
+}
+
+async function promptCoverageFileReselect(): Promise<File | null> {
+    const pickerWindow = window as FilePickerWindow;
+    if (pickerWindow.showOpenFilePicker) {
+        try {
+            const [handle] = await pickerWindow.showOpenFilePicker({
+                multiple: false,
+                types: [
+                    {
+                        description: "Bucket Archive",
+                        accept: {
+                            "application/gzip": [".bktgz"],
+                        },
+                    },
+                ],
+            });
+            if (!handle) {
+                return null;
+            }
+            return handle.getFile();
+        } catch {
+            return null;
+        }
+    }
+
+    return new Promise((resolve) => {
+        const input = document.createElement("input");
+        input.type = "file";
+        input.accept = ".bktgz";
+        input.style.display = "none";
+        document.body.appendChild(input);
+
+        let settled = false;
+        const cleanup = () => {
+            window.removeEventListener("focus", onFocus, true);
+            input.remove();
+        };
+        const finish = (file: File | null) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            cleanup();
+            resolve(file);
+        };
+        const onFocus = () => {
+            setTimeout(() => {
+                if (!settled) {
+                    finish(null);
+                }
+            }, 500);
+        };
+
+        input.onchange = () => {
+            const file = input.files?.[0] ?? null;
+            finish(file);
+        };
+
+        window.addEventListener("focus", onFocus, true);
+        input.click();
+    });
+}
+
 export function useFileLoader() {
-    const [tree, setTree] = useState<CoverageTree>(getDefaultTree);
+    const [session, setSession] = useState<CoverageSession>(getDefaultSession);
     const [isLoading, setIsLoading] = useState(false);
     const [isDragging, setIsDragging] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const sourceCounterRef = useRef(1);
+    const recordCounterRef = useRef(1);
 
-    /**
-     * Load a file and update the tree state
-     */
-    const loadFile = async (loadFn: () => Promise<CoverageTree>, suppressNotification: boolean = false): Promise<{ success: boolean }> => {
+    const tree = useMemo(() => {
+        const loadedSet = new Set(session.loadedRecordIds);
+        const loadedReadouts = session.records
+            .filter((record) => loadedSet.has(record.id))
+            .map((record) => record.readout);
+        return CoverageTree.fromReadouts(loadedReadouts);
+    }, [session.loadedRecordIds, session.records]);
+
+    const setSessionFromSources = (
+        sourcePayloads: SourceLoadPayload[],
+        mode: LoadMode,
+    ): void => {
+        const sources: CoverageSourceRef[] = [];
+        const records: CoverageRecord[] = [];
+
+        for (const payload of sourcePayloads) {
+            const sourceId = `source-${sourceCounterRef.current++}`;
+            const sourceRef: CoverageSourceRef = {
+                id: sourceId,
+                ...payload.source,
+            };
+            sources.push(sourceRef);
+            for (const [index, readout] of payload.readouts.entries()) {
+                records.push({
+                    id: `record-${recordCounterRef.current++}`,
+                    readout,
+                    sourceRef: sourceId,
+                    sourceRecordIndex: index,
+                    isLoaded: true,
+                });
+            }
+        }
+
+        const loadedRecordIds = records.map((record) => record.id);
+        if (mode === "replace") {
+            setSession({
+                sources,
+                records,
+                loadedRecordIds,
+            });
+            return;
+        }
+
+        setSession((current) => {
+            const mergedLoaded = new Set(current.loadedRecordIds);
+            for (const loadedId of loadedRecordIds) {
+                mergedLoaded.add(loadedId);
+            }
+            return {
+                sources: [...current.sources, ...sources],
+                records: [...current.records, ...records],
+                loadedRecordIds: Array.from(mergedLoaded),
+            };
+        });
+    };
+
+    const loadWithSources = async (
+        loadFn: () => Promise<SourceLoadPayload[]>,
+        suppressNotification: boolean = false,
+        mode: LoadMode = "append",
+    ): Promise<{ success: boolean }> => {
         setIsLoading(true);
         setError(null);
         try {
-            const newTree = await loadFn();
-            setTree(newTree);
+            const payloads = await loadFn();
+            if (payloads.length === 0) {
+                throw new Error("No coverage files selected.");
+            }
+            setSessionFromSources(payloads, mode);
             return { success: true };
         } catch (err) {
             const errorMessage = err instanceof Error ? err.message : String(err);
-            console.error("Failed to load file:", err);
             setError(errorMessage);
             if (!suppressNotification) {
-                if (errorMessage.includes('no coverage data')) {
+                if (isNoCoverageError(errorMessage)) {
                     notification.error({
-                        message: 'No Coverage Data',
-                        description: 'The loaded .bktgz file contains no coverage data. Please ensure the file was exported correctly from a Bucket coverage run.',
+                        message: "No Coverage Data",
+                        description:
+                            "The loaded .bktgz file contains no coverage data. Please ensure the file was exported correctly from a Bucket coverage run.",
                         duration: 5,
                     });
                 } else {
                     notification.error({
-                        message: 'Failed to Load File',
+                        message: "Failed to Load File",
                         description: errorMessage,
                         duration: 5,
                     });
@@ -66,199 +223,456 @@ export function useFileLoader() {
         }
     };
 
-    /**
-     * Handle file input change (web browser file picker)
-     */
     const handleFileInput = async (event: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
-        const file = event.target.files?.[0];
-        if (file) {
-            await loadFile(() => loadFileFromFileObject(file));
+        const files = Array.from(event.target.files ?? []).filter((file) =>
+            file.name.endsWith(".bktgz"),
+        );
+        if (files.length > 0) {
+            await loadWithSources(async () => {
+                const payloads: SourceLoadPayload[] = [];
+                for (const file of files) {
+                    payloads.push({
+                        readouts: await loadReadoutsFromFileObject(file),
+                        source: {
+                            kind: "fileObject",
+                            label: file.name,
+                            fileObject: file,
+                        },
+                    });
+                }
+                return payloads;
+            });
         }
-        // Reset input so same file can be selected again
         if (event.target) {
-            event.target.value = '';
+            event.target.value = "";
         }
     };
 
-    /**
-     * Open file dialog (Electron or web browser)
-     */
     const openFileDialog = async (): Promise<void> => {
         if (isElectron() && window.electronAPI) {
-            // Electron file picker - use loadFile for consistent error handling
-            await loadFile(async () => {
-                const result = await openElectronFileDialog();
-                if (!result) {
-                    throw new Error('File selection was cancelled');
+            const filePaths = await openElectronFileDialog();
+            if (!filePaths || filePaths.length === 0) {
+                return;
+            }
+            await loadWithSources(async () => {
+                const payloads: SourceLoadPayload[] = [];
+                for (const filePath of filePaths) {
+                    payloads.push({
+                        readouts: await loadReadoutsFromElectronPath(filePath),
+                        source: {
+                            kind: "electronPath",
+                            label: filePath.split(/[\\/]/).pop() ?? filePath,
+                            path: filePath,
+                        },
+                    });
                 }
-                return result;
-            }); // loadFile will show notifications
-        } else {
-            // Web browser file picker
-            fileInputRef.current?.click();
+                return payloads;
+            });
+            return;
         }
+        fileInputRef.current?.click();
     };
 
-    /**
-     * Clear coverage data and reset to empty tree
-     */
     const clearCoverage = (): void => {
         Modal.confirm({
-            title: 'Clear Coverage',
-            content: 'Are you sure you want to clear all coverage data?',
-            okText: 'Clear',
-            okType: 'danger',
-            cancelText: 'Cancel',
+            title: "Clear Coverage",
+            content: "Are you sure you want to clear all coverage data?",
+            okText: "Clear",
+            okType: "danger",
+            cancelText: "Cancel",
             onOk: () => {
-                setTree(getDefaultTree());
+                setSession(getDefaultSession());
                 setError(null);
             },
         });
     };
 
-    /**
-     * Handle drag and drop
-     */
+    const setLoadedRecords = (loadedRecordIds: string[]): void => {
+        const loadedSet = new Set(loadedRecordIds);
+        setSession((current) => ({
+            ...current,
+            loadedRecordIds,
+            records: current.records.map((record) => ({
+                ...record,
+                isLoaded: loadedSet.has(record.id),
+            })),
+        }));
+    };
+
+    const mergeRecords = async (recordIds: string[]): Promise<void> => {
+        const selected = session.records.filter((record) => recordIds.includes(record.id));
+        if (selected.length < 2) {
+            notification.warning({
+                message: "Merge Requires Two or More Records",
+                description: "Select at least two records to merge.",
+                duration: 4,
+            });
+            return;
+        }
+
+        try {
+            const mergedReadout = mergeReadoutsStrict(selected.map((record) => record.readout));
+            const sourceId = `source-${sourceCounterRef.current++}`;
+            const mergedSource: CoverageSourceRef = {
+                id: sourceId,
+                kind: "virtualMerged",
+                label: mergedReadout.get_source() ?? "Merged Record",
+            };
+            const mergedRecord: CoverageRecord = {
+                id: `record-${recordCounterRef.current++}`,
+                readout: mergedReadout,
+                sourceRef: sourceId,
+                sourceRecordIndex: 0,
+                isLoaded: true,
+            };
+            setSession((current) => ({
+                sources: [...current.sources, mergedSource],
+                records: [...current.records, mergedRecord],
+                loadedRecordIds: [...current.loadedRecordIds, mergedRecord.id],
+            }));
+            notification.success({
+                message: "Records Merged",
+                description: "Merged record added and loaded.",
+                duration: 3,
+            });
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : String(err);
+            notification.error({
+                message: "Merge Failed",
+                description: errorMessage,
+                duration: 5,
+            });
+        }
+    };
+
+    const refreshLoadedRecords = async (): Promise<void> => {
+        setIsLoading(true);
+        setError(null);
+
+        const warnings: RefreshWarning[] = [];
+        const refreshedRecordIds: string[] = [];
+
+        try {
+            const nextSources = session.sources.map((source) => ({ ...source }));
+            const nextRecords = session.records.map((record) => ({ ...record }));
+            const sourceById = new Map(nextSources.map((source) => [source.id, source]));
+
+            const recordsBySource = new Map<string, CoverageRecord[]>();
+            for (const record of nextRecords) {
+                if (!record.isLoaded) {
+                    continue;
+                }
+                const source = sourceById.get(record.sourceRef);
+                if (!source || source.kind === "virtualMerged") {
+                    continue;
+                }
+                const group = recordsBySource.get(source.id) ?? [];
+                group.push(record);
+                recordsBySource.set(source.id, group);
+            }
+
+            for (const [sourceId, records] of recordsBySource.entries()) {
+                const source = sourceById.get(sourceId);
+                if (!source) {
+                    continue;
+                }
+
+                let refreshedReadouts: Readout[] | null = null;
+                try {
+                    if (source.kind === "electronPath") {
+                        if (!source.path) {
+                            throw new Error("Missing source file path.");
+                        }
+                        refreshedReadouts = await loadReadoutsFromElectronPath(source.path);
+                    } else if (source.kind === "fileHandle") {
+                        if (!source.fileHandle) {
+                            throw new Error("Missing file handle.");
+                        }
+                        refreshedReadouts = await loadReadoutsFromFileHandle(source.fileHandle);
+                    } else if (source.kind === "fileObject") {
+                        const replacementFile = await promptCoverageFileReselect();
+                        if (!replacementFile) {
+                            warnings.push({
+                                sourceLabel: source.label,
+                                detail: "Refresh canceled; keeping currently loaded record(s).",
+                            });
+                            continue;
+                        }
+                        source.fileObject = replacementFile;
+                        source.label = replacementFile.name;
+                        refreshedReadouts = await loadReadoutsFromFileObject(replacementFile);
+                    }
+                } catch (err) {
+                    const message = err instanceof Error ? err.message : String(err);
+                    warnings.push({
+                        sourceLabel: source.label,
+                        detail: `Skipping refresh: ${message}`,
+                    });
+                    continue;
+                }
+
+                if (!refreshedReadouts) {
+                    continue;
+                }
+
+                for (const record of records) {
+                    const refreshed = refreshedReadouts[record.sourceRecordIndex];
+                    if (!refreshed) {
+                        warnings.push({
+                            sourceLabel: source.label,
+                            detail: `Record index ${record.sourceRecordIndex} no longer exists; kept stale record.`,
+                        });
+                        continue;
+                    }
+                    record.readout = refreshed;
+                    refreshedRecordIds.push(record.id);
+                }
+            }
+
+            setSession({
+                sources: nextSources,
+                records: nextRecords,
+                loadedRecordIds: session.loadedRecordIds,
+            });
+
+            if (refreshedRecordIds.length > 0) {
+                notification.success({
+                    message: "Refresh Complete",
+                    description: `Refreshed ${refreshedRecordIds.length} loaded record(s).`,
+                    duration: 3,
+                });
+            } else {
+                notification.info({
+                    message: "Nothing Refreshed",
+                    description: "No loaded file-backed records were refreshed.",
+                    duration: 3,
+                });
+            }
+
+            if (warnings.length > 0) {
+                notification.warning({
+                    message: "Refresh Warnings",
+                    description: warnings
+                        .map((warning) => `${warning.sourceLabel}: ${warning.detail}`)
+                        .join(" "),
+                    duration: 7,
+                });
+            }
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : String(err);
+            setError(errorMessage);
+            notification.error({
+                message: "Refresh Failed",
+                description: errorMessage,
+                duration: 5,
+            });
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const exportRecords = async (options: {
+        recordIds: string[];
+        format: ExportFormat;
+        mergeBeforeExport: boolean;
+        fileBaseName?: string;
+    }): Promise<void> => {
+        const selected = session.records.filter(
+            (record) => record.isLoaded && options.recordIds.includes(record.id),
+        );
+        if (selected.length === 0) {
+            notification.warning({
+                message: "No Records Selected",
+                description: "Select at least one loaded record to export.",
+                duration: 4,
+            });
+            return;
+        }
+
+        try {
+            const exportReadouts = options.mergeBeforeExport
+                ? [mergeReadoutsStrict(selected.map((record) => record.readout))]
+                : selected.map((record) => record.readout);
+            const bytes = serializeReadouts(exportReadouts, options.format);
+            const defaultFileName = getDefaultExportFileName(
+                options.format,
+                options.mergeBeforeExport,
+            );
+            const defaultBaseName = defaultFileName.replace(/\.(bktgz|json)$/i, "");
+            const rawBaseName = (options.fileBaseName ?? "").trim();
+            const extension = options.format === "json" ? ".json" : ".bktgz";
+            const safeBaseName =
+                rawBaseName.length === 0
+                    ? defaultBaseName
+                    : rawBaseName.replace(/\.(bktgz|json)$/i, "");
+            const fileName =
+                safeBaseName.length === 0 ? defaultBaseName + extension : `${safeBaseName}${extension}`;
+            const result = await saveExportBytes(bytes, options.format, fileName);
+            if (!result.canceled) {
+                notification.success({
+                    message: "Export Complete",
+                    description: `Exported ${exportReadouts.length} record(s).`,
+                    duration: 3,
+                });
+            }
+        } catch (err) {
+            const errorMessage = err instanceof Error ? err.message : String(err);
+            notification.error({
+                message: "Export Failed",
+                description: errorMessage,
+                duration: 5,
+            });
+        }
+    };
+
     const handleDrop = async (e: DragEvent): Promise<void> => {
         e.preventDefault();
         e.stopPropagation();
         setIsDragging(false);
         const files = e.dataTransfer?.files;
         if (files && files.length > 0) {
-            const file = files[0];
-            if (file.name.endsWith('.bktgz')) {
-                await loadFile(() => loadFileFromFileObject(file));
+            const archiveFiles = Array.from(files).filter((file) =>
+                file.name.endsWith(".bktgz"),
+            );
+            if (archiveFiles.length > 0) {
+                await loadWithSources(async () => {
+                    const payloads: SourceLoadPayload[] = [];
+                    for (const file of archiveFiles) {
+                        payloads.push({
+                            readouts: await loadReadoutsFromFileObject(file),
+                            source: {
+                                kind: "fileObject",
+                                label: file.name,
+                                fileObject: file,
+                            },
+                        });
+                    }
+                    return payloads;
+                });
             } else {
                 notification.warning({
-                    message: 'Invalid File Type',
-                    description: 'Please drop a .bktgz file.',
+                    message: "Invalid File Type",
+                    description: "Please drop a .bktgz file.",
                     duration: 3,
                 });
             }
         }
     };
 
-    /**
-     * Handle drag over (prevent default to allow drop)
-     */
     const handleDragOver = (e: DragEvent): void => {
         const isPivotAxisDrag = e.dataTransfer?.types?.includes("application/x-pivot-axis");
-        // Always prevent default browser handling so we don't trigger navigation or
-        // other native drag behaviors, even when the pivot table owns the drag.
         e.preventDefault();
         if (isPivotAxisDrag) {
-            // Let the event propagate so the pivot table's own handlers still run.
             return;
         }
         e.stopPropagation();
         if (e.dataTransfer) {
-            e.dataTransfer.dropEffect = 'copy';
+            e.dataTransfer.dropEffect = "copy";
         }
         setIsDragging(true);
     };
 
-    /**
-     * Handle drag enter
-     */
     const handleDragEnter = (e: DragEvent): void => {
         const isPivotAxisDrag = e.dataTransfer?.types?.includes("application/x-pivot-axis");
-        // Always prevent default browser handling so we don't trigger navigation or
-        // other native drag behaviors, even when the pivot table owns the drag.
         e.preventDefault();
         if (isPivotAxisDrag) {
-            // Let the event propagate so the pivot table's own handlers still run.
             return;
         }
         e.stopPropagation();
         if (e.dataTransfer) {
-            e.dataTransfer.dropEffect = 'copy';
+            e.dataTransfer.dropEffect = "copy";
         }
         setIsDragging(true);
     };
 
-    /**
-     * Handle drag leave
-     */
     const handleDragLeave = (e: DragEvent): void => {
         e.preventDefault();
         e.stopPropagation();
-        // Only set dragging to false if we're leaving the window
         if (!e.relatedTarget || (e.relatedTarget as Node).nodeType === Node.DOCUMENT_NODE) {
             setIsDragging(false);
         }
     };
 
-    // Set up event listeners and Electron handlers
     useEffect(() => {
-        // Chrome PWA file handling: Handle files opened directly via PWA file association
-        // This allows users to open .bktgz files directly from the OS when the app
-        // is installed as a PWA (Progressive Web App)
         if ("launchQueue" in window && window.launchQueue) {
-            window.launchQueue.setConsumer(async (launchParams: { files: FileSystemFileHandle[] }) => {
-                try {
-                    for (const file of launchParams.files) {
-                        await loadFile(() => loadFileFromFileHandle(file));
+            window.launchQueue.setConsumer(
+                async (launchParams: { files: FileSystemFileHandle[] }) => {
+                    try {
+                        await loadWithSources(async () => {
+                            const payloads: SourceLoadPayload[] = [];
+                            for (const fileHandle of launchParams.files) {
+                                payloads.push({
+                                    readouts: await loadReadoutsFromFileHandle(fileHandle),
+                                    source: {
+                                        kind: "fileHandle",
+                                        label: fileHandle.name,
+                                        fileHandle,
+                                    },
+                                });
+                            }
+                            return payloads;
+                        });
+                    } catch (err) {
+                        notification.error({
+                            message: "Failed to Load File",
+                            description: err instanceof Error ? err.message : String(err),
+                            duration: 5,
+                        });
                     }
-                } catch (error) {
-                    console.error("Failed to load file from PWA launchQueue:", error);
-                    notification.error({
-                        message: 'Failed to Load File',
-                        description: error instanceof Error ? error.message : String(error),
-                        duration: 5,
-                    });
-                }
-            });
+                },
+            );
         }
 
-        // Handle drag and drop (works in both Electron and web browsers)
         const rootElement = document.documentElement;
-        rootElement.addEventListener('drop', handleDrop);
-        rootElement.addEventListener('dragover', handleDragOver);
-        rootElement.addEventListener('dragenter', handleDragEnter);
-        rootElement.addEventListener('dragleave', handleDragLeave);
+        rootElement.addEventListener("drop", handleDrop);
+        rootElement.addEventListener("dragover", handleDragOver);
+        rootElement.addEventListener("dragenter", handleDragEnter);
+        rootElement.addEventListener("dragleave", handleDragLeave);
 
-        // Electron-specific: Handle files opened via app.open-file (macOS) or menu
-        // The onFilesOpened API receives an array of file paths to support multi-file
-        // selection in the future. Currently, we process each file sequentially.
         if (isElectron() && window.electronAPI) {
             const electronAPI = window.electronAPI;
             electronAPI.onFilesOpened(async (filePaths: string[]) => {
                 try {
-                    for (const filePath of filePaths) {
-                        const bytes = await electronAPI.readFile(filePath);
-                        await loadFile(() => loadFileFromBytes(bytes));
-                    }
-                } catch (error) {
-                    console.error("Failed to open file:", error);
+                    await loadWithSources(async () => {
+                        const payloads: SourceLoadPayload[] = [];
+                        for (const filePath of filePaths) {
+                            payloads.push({
+                                readouts: await loadReadoutsFromElectronPath(filePath),
+                                source: {
+                                    kind: "electronPath",
+                                    label: filePath.split(/[\\/]/).pop() ?? filePath,
+                                    path: filePath,
+                                },
+                            });
+                        }
+                        return payloads;
+                    });
+                } catch (err) {
                     notification.error({
-                        message: 'Failed to Open File',
-                        description: error instanceof Error ? error.message : String(error),
+                        message: "Failed to Open File",
+                        description: err instanceof Error ? err.message : String(err),
                         duration: 5,
                     });
                 }
             });
 
-            // Handle clear coverage event from Electron
             electronAPI.onClearCoverage(() => {
                 clearCoverage();
             });
         }
 
         return () => {
-            rootElement.removeEventListener('drop', handleDrop);
-            rootElement.removeEventListener('dragover', handleDragOver);
-            rootElement.removeEventListener('dragenter', handleDragEnter);
-            rootElement.removeEventListener('dragleave', handleDragLeave);
+            rootElement.removeEventListener("drop", handleDrop);
+            rootElement.removeEventListener("dragover", handleDragOver);
+            rootElement.removeEventListener("dragenter", handleDragEnter);
+            rootElement.removeEventListener("dragleave", handleDragLeave);
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        // Intentionally empty deps: This effect should run only once on mount to set up
-        // event listeners and IPC handlers. The handlers (loadFile, handleDrop, etc.)
-        // are stable functions that don't need to be in the dependency array.
     }, []);
 
     return {
         tree,
-        setTree,
+        session,
         isLoading,
         isDragging,
         error,
@@ -266,5 +680,9 @@ export function useFileLoader() {
         handleFileInput,
         openFileDialog,
         clearCoverage,
+        setLoadedRecords,
+        mergeRecords,
+        refreshLoadedRecords,
+        exportRecords,
     };
 }

--- a/viewer/src/routes/index.tsx
+++ b/viewer/src/routes/index.tsx
@@ -9,7 +9,20 @@ import { useFileLoader } from "@/hooks/useFileLoader";
 import { Spin } from "antd";
 
 export const AppRoutes = () => {
-    const { tree, isLoading, isDragging, fileInputRef, handleFileInput, openFileDialog, clearCoverage } = useFileLoader();
+    const {
+        tree,
+        session,
+        isLoading,
+        isDragging,
+        fileInputRef,
+        handleFileInput,
+        openFileDialog,
+        clearCoverage,
+        setLoadedRecords,
+        mergeRecords,
+        refreshLoadedRecords,
+        exportRecords,
+    } = useFileLoader();
 
     const element = useRoutes([
         {
@@ -22,10 +35,22 @@ export const AppRoutes = () => {
                         ref={fileInputRef}
                         onChange={handleFileInput}
                         accept=".bktgz"
+                        multiple
                         style={{ display: 'none' }}
                     />
                     <Spin spinning={isLoading} size="large" tip="Loading coverage data...">
-                        <Dashboard tree={tree} onOpenFile={openFileDialog} onClearCoverage={clearCoverage} isDragging={isDragging} />
+                        <Dashboard
+                            tree={tree}
+                            records={session.records}
+                            sources={session.sources}
+                            onOpenFile={openFileDialog}
+                            onClearCoverage={clearCoverage}
+                            onSetLoadedRecords={setLoadedRecords}
+                            onMergeRecords={mergeRecords}
+                            onRefreshRecords={refreshLoadedRecords}
+                            onExportRecords={exportRecords}
+                            isDragging={isDragging}
+                        />
                     </Spin>
                 </>
             ),

--- a/viewer/src/services/exportSaver.ts
+++ b/viewer/src/services/exportSaver.ts
@@ -29,6 +29,14 @@ function getExtension(format: ExportFormat): string {
     return format === "json" ? "json" : "bktgz";
 }
 
+/** User closed the save picker without choosing a file — not a write failure. */
+function isSavePickerUserAbort(error: unknown): boolean {
+    if (error instanceof DOMException && error.name === "AbortError") {
+        return true;
+    }
+    return error instanceof Error && error.name === "AbortError";
+}
+
 export function getDefaultExportFileName(format: ExportFormat, merged: boolean): string {
     const now = new Date();
     const year = now.getFullYear();
@@ -78,7 +86,10 @@ export async function saveExportBytes(
             await writable.close();
             return { canceled: false };
         } catch (error) {
-            return { canceled: true };
+            if (isSavePickerUserAbort(error)) {
+                return { canceled: true };
+            }
+            throw error instanceof Error ? error : new Error(String(error));
         }
     }
 

--- a/viewer/src/services/exportSaver.ts
+++ b/viewer/src/services/exportSaver.ts
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+ */
+
+import type { ExportFormat } from "@/types/coverageSession";
+import { isElectron } from "@/services/fileLoader";
+
+type SaveResult = {
+    canceled: boolean;
+    path?: string;
+};
+
+type SaveFilePickerWindow = Window & {
+    showSaveFilePicker?: (options?: {
+        suggestedName?: string;
+        types?: Array<{
+            description?: string;
+            accept: Record<string, string[]>;
+        }>;
+    }) => Promise<FileSystemFileHandle>;
+};
+
+function getMimeType(format: ExportFormat): string {
+    return format === "json" ? "application/json" : "application/gzip";
+}
+
+function getExtension(format: ExportFormat): string {
+    return format === "json" ? "json" : "bktgz";
+}
+
+export function getDefaultExportFileName(format: ExportFormat, merged: boolean): string {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    const hour = String(now.getHours()).padStart(2, "0");
+    const minute = String(now.getMinutes()).padStart(2, "0");
+    const second = String(now.getSeconds()).padStart(2, "0");
+    const prefix = merged ? "bucket_merged" : "bucket_export";
+    return `${prefix}_${year}${month}${day}_${hour}${minute}${second}.${getExtension(format)}`;
+}
+
+export async function saveExportBytes(
+    bytes: Uint8Array,
+    format: ExportFormat,
+    defaultFileName: string,
+): Promise<SaveResult> {
+    const arrayBuffer = bytes.buffer.slice(
+        bytes.byteOffset,
+        bytes.byteOffset + bytes.byteLength,
+    ) as ArrayBuffer;
+
+    if (isElectron() && window.electronAPI?.saveExportFile) {
+        return window.electronAPI.saveExportFile({
+            bytes: Array.from(bytes),
+            format,
+            defaultFileName,
+        });
+    }
+
+    const pickerWindow = window as SaveFilePickerWindow;
+    if (pickerWindow.showSaveFilePicker) {
+        try {
+            const handle = await pickerWindow.showSaveFilePicker({
+                suggestedName: defaultFileName,
+                types: [
+                    {
+                        description: format === "json" ? "JSON Coverage" : "Bucket Archive",
+                        accept: {
+                            [getMimeType(format)]: [`.${getExtension(format)}`],
+                        },
+                    },
+                ],
+            });
+            const writable = await handle.createWritable();
+            await writable.write(arrayBuffer);
+            await writable.close();
+            return { canceled: false };
+        } catch (error) {
+            return { canceled: true };
+        }
+    }
+
+    const blob = new Blob([arrayBuffer], { type: getMimeType(format) });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = defaultFileName;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+    return { canceled: false };
+}

--- a/viewer/src/services/exportSerializers.test.ts
+++ b/viewer/src/services/exportSerializers.test.ts
@@ -1,0 +1,163 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+ */
+
+import { describe, expect, test } from "vitest";
+import { InMemoryReadout, mergeReadoutsStrict } from "@/services/readoutUtils";
+import {
+    serializeReadoutsToArchiveBytes,
+    serializeReadoutsToJsonBytes,
+} from "@/services/exportSerializers";
+import { readElectronFile } from "../features/Dashboard/lib/readers";
+
+function createReadout(overrides?: {
+    defSha?: string;
+    recSha?: string;
+    source?: string | null;
+    sourceKey?: string | null;
+    bucketHits?: number[];
+}): Readout {
+    const bucketHits = overrides?.bucketHits ?? [2, 1];
+    return new InMemoryReadout({
+        defSha: overrides?.defSha ?? "def-a",
+        recSha: overrides?.recSha ?? "rec-a",
+        source: overrides?.source ?? "suite",
+        sourceKey: overrides?.sourceKey ?? "test",
+        points: [
+            {
+                start: 0,
+                depth: 0,
+                end: 1,
+                axis_start: 0,
+                axis_end: 1,
+                axis_value_start: 0,
+                axis_value_end: 2,
+                goal_start: 0,
+                goal_end: 2,
+                bucket_start: 0,
+                bucket_end: 2,
+                target: 4,
+                target_buckets: 2,
+                name: "Root",
+                description: "Root",
+            },
+        ],
+        bucketGoals: [
+            { start: 0, goal: 0 },
+            { start: 1, goal: 1 },
+        ],
+        axes: [
+            {
+                start: 0,
+                value_start: 0,
+                value_end: 2,
+                name: "axis",
+                description: "axis desc",
+            },
+        ],
+        axisValues: [
+            { start: 0, value: "A" },
+            { start: 1, value: "B" },
+        ],
+        goals: [
+            { start: 0, target: 3, name: "goal0", description: "g0" },
+            { start: 1, target: 2, name: "goal1", description: "g1" },
+        ],
+        pointHits: [
+            {
+                start: 0,
+                depth: 0,
+                hits: Math.min(bucketHits[0], 3) + Math.min(bucketHits[1], 2),
+                hit_buckets: bucketHits.filter((value) => value > 0).length,
+                full_buckets: [
+                    bucketHits[0] >= 3 ? 1 : 0,
+                    bucketHits[1] >= 2 ? 1 : 0,
+                ].reduce((a, b) => a + b, 0),
+            },
+        ],
+        bucketHits: [
+            { start: 0, hits: bucketHits[0] },
+            { start: 1, hits: bucketHits[1] },
+        ],
+    });
+}
+
+async function readSingle(bytes: Uint8Array): Promise<Readout> {
+    const reader = await readElectronFile(Array.from(bytes));
+    const readouts: Readout[] = [];
+    for await (const readout of reader.read_all()) {
+        readouts.push(readout);
+    }
+    expect(readouts).toHaveLength(1);
+    return readouts[0];
+}
+
+describe("mergeReadoutsStrict", () => {
+    test("merges bucket hits and preserves originals", () => {
+        const readoutA = createReadout({ bucketHits: [1, 2] });
+        const readoutB = createReadout({ bucketHits: [3, 4] });
+
+        const merged = mergeReadoutsStrict([readoutA, readoutB]);
+        const mergedBucketHits = Array.from(merged.iter_bucket_hits(0, null)).map(
+            (value) => value.hits,
+        );
+        expect(mergedBucketHits).toEqual([4, 6]);
+
+        // Originals are unchanged
+        expect(Array.from(readoutA.iter_bucket_hits(0, null)).map((value) => value.hits)).toEqual(
+            [1, 2],
+        );
+        expect(Array.from(readoutB.iter_bucket_hits(0, null)).map((value) => value.hits)).toEqual(
+            [3, 4],
+        );
+        expect(merged.get_source()).toMatch(/^Merged_/);
+        expect(merged.get_source_key()).toBe("");
+    });
+
+    test("rejects def hash mismatch", () => {
+        const readoutA = createReadout({ defSha: "def-a" });
+        const readoutB = createReadout({ defSha: "def-b" });
+        expect(() => mergeReadoutsStrict([readoutA, readoutB])).toThrow(
+            "Tried to merge coverage with two different definition hashes!",
+        );
+    });
+
+    test("rejects rec hash mismatch", () => {
+        const readoutA = createReadout({ recSha: "rec-a" });
+        const readoutB = createReadout({ recSha: "rec-b" });
+        expect(() => mergeReadoutsStrict([readoutA, readoutB])).toThrow(
+            "Tried to merge coverage with two different record hashes!",
+        );
+    });
+});
+
+describe("export serializers", () => {
+    test("round-trips json serialization through reader", async () => {
+        const readout = createReadout({ bucketHits: [5, 6], source: "json", sourceKey: "r0" });
+        const bytes = serializeReadoutsToJsonBytes([readout]);
+        const restored = await readSingle(bytes);
+
+        expect(restored.get_def_sha()).toBe(readout.get_def_sha());
+        expect(restored.get_rec_sha()).toBe(readout.get_rec_sha());
+        expect(restored.get_source()).toBe("json");
+        expect(restored.get_source_key()).toBe("r0");
+        expect(Array.from(restored.iter_bucket_hits(0, null)).map((value) => value.hits)).toEqual(
+            [5, 6],
+        );
+    });
+
+    test("round-trips archive serialization through reader", async () => {
+        const readout = createReadout({ bucketHits: [7, 8], source: "archive", sourceKey: "r1" });
+        const bytes = serializeReadoutsToArchiveBytes([readout]);
+        const restored = await readSingle(bytes);
+
+        expect(restored.get_def_sha()).toBe(readout.get_def_sha());
+        expect(restored.get_rec_sha()).toBe(readout.get_rec_sha());
+        expect(restored.get_source()).toBe("archive");
+        expect(restored.get_source_key()).toBe("r1");
+        expect(Array.from(restored.iter_bucket_hits(0, null)).map((value) => value.hits)).toEqual(
+            [7, 8],
+        );
+    });
+});

--- a/viewer/src/services/exportSerializers.ts
+++ b/viewer/src/services/exportSerializers.ts
@@ -1,0 +1,333 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+ */
+
+import { gzipSync } from "fflate";
+import type { ExportFormat } from "@/types/coverageSession";
+import { materializeReadout } from "@/services/readoutUtils";
+
+type JsonCoverageData = {
+    tables: Record<string, string[]>;
+    definitions: Record<string, unknown>[];
+    records: Record<string, unknown>[];
+};
+
+type CsvValue = string | number | null;
+
+const JSON_TABLES: Record<string, string[]> = {
+    point: [
+        "start",
+        "depth",
+        "end",
+        "axis_start",
+        "axis_end",
+        "axis_value_start",
+        "axis_value_end",
+        "goal_start",
+        "goal_end",
+        "bucket_start",
+        "bucket_end",
+        "target",
+        "target_buckets",
+        "name",
+        "description",
+    ],
+    axis: ["start", "value_start", "value_end", "name", "description"],
+    axis_value: ["start", "value"],
+    goal: ["start", "target", "name", "description"],
+    bucket_goal: ["start", "goal"],
+    point_hit: ["start", "depth", "hits", "hit_buckets", "full_buckets"],
+    bucket_hit: ["start", "hits"],
+};
+
+class CsvTableBuilder {
+    private chunks: string[] = [];
+    private byteLength = 0;
+    private encoder = new TextEncoder();
+
+    writeRows(rows: CsvValue[][]): { start: number; end: number } {
+        const start = this.byteLength;
+        for (const row of rows) {
+            const line = `${row.map(encodeCsvCell).join(",")}\n`;
+            this.chunks.push(line);
+            this.byteLength += this.encoder.encode(line).length;
+        }
+        return { start, end: this.byteLength };
+    }
+
+    toBytes(): Uint8Array {
+        return this.encoder.encode(this.chunks.join(""));
+    }
+}
+
+function encodeCsvCell(value: CsvValue): string {
+    const text = value === null || value === undefined ? "" : String(value);
+    return `"${text.replace(/"/g, '""')}"`;
+}
+
+function writeAscii(target: Uint8Array, offset: number, length: number, value: string): void {
+    const limit = Math.min(length, value.length);
+    for (let idx = 0; idx < limit; idx += 1) {
+        target[offset + idx] = value.charCodeAt(idx);
+    }
+}
+
+function writeOctal(target: Uint8Array, offset: number, length: number, value: number): void {
+    const maxDigits = Math.max(length - 1, 1);
+    const octal = Math.max(0, value).toString(8).padStart(maxDigits, "0");
+    writeAscii(target, offset, maxDigits, octal.slice(-maxDigits));
+    target[offset + length - 1] = 0;
+}
+
+function writeChecksum(target: Uint8Array, value: number): void {
+    const octal = Math.max(0, value).toString(8).padStart(6, "0").slice(-6);
+    writeAscii(target, 148, 6, octal);
+    target[154] = 0;
+    target[155] = 32;
+}
+
+function createTar(entries: { name: string; data: Uint8Array }[]): Uint8Array {
+    const parts: Uint8Array[] = [];
+    let totalLength = 0;
+    const now = Math.floor(Date.now() / 1000);
+
+    for (const entry of entries) {
+        const header = new Uint8Array(512);
+        writeAscii(header, 0, 100, entry.name);
+        writeOctal(header, 100, 8, 0o644);
+        writeOctal(header, 108, 8, 0);
+        writeOctal(header, 116, 8, 0);
+        writeOctal(header, 124, 12, entry.data.length);
+        writeOctal(header, 136, 12, now);
+        for (let idx = 148; idx < 156; idx += 1) {
+            header[idx] = 32;
+        }
+        header[156] = "0".charCodeAt(0);
+        writeAscii(header, 257, 5, "ustar");
+        header[262] = 0;
+        writeAscii(header, 263, 2, "00");
+
+        const checksum = header.reduce((sum, byte) => sum + byte, 0);
+        writeChecksum(header, checksum);
+
+        parts.push(header);
+        totalLength += header.length;
+
+        parts.push(entry.data);
+        totalLength += entry.data.length;
+
+        const padLength = (512 - (entry.data.length % 512)) % 512;
+        if (padLength > 0) {
+            const padding = new Uint8Array(padLength);
+            parts.push(padding);
+            totalLength += padding.length;
+        }
+    }
+
+    const endBlocks = new Uint8Array(1024);
+    parts.push(endBlocks);
+    totalLength += endBlocks.length;
+
+    const tarBytes = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const part of parts) {
+        tarBytes.set(part, offset);
+        offset += part.length;
+    }
+    return tarBytes;
+}
+
+export function serializeReadoutsToJsonBytes(readouts: Readout[]): Uint8Array {
+    const payload: JsonCoverageData = {
+        tables: JSON_TABLES,
+        definitions: [],
+        records: [],
+    };
+
+    for (const readout of readouts) {
+        const data = materializeReadout(readout);
+        const definitionIndex = payload.definitions.length;
+        payload.definitions.push({
+            sha: data.defSha,
+            point: data.points.map((point) => [
+                point.start,
+                point.depth,
+                point.end,
+                point.axis_start,
+                point.axis_end,
+                point.axis_value_start,
+                point.axis_value_end,
+                point.goal_start,
+                point.goal_end,
+                point.bucket_start,
+                point.bucket_end,
+                point.target,
+                point.target_buckets,
+                point.name,
+                point.description,
+            ]),
+            axis: data.axes.map((axis) => [
+                axis.start,
+                axis.value_start,
+                axis.value_end,
+                axis.name,
+                axis.description,
+            ]),
+            axis_value: data.axisValues.map((axisValue) => [
+                axisValue.start,
+                axisValue.value,
+            ]),
+            goal: data.goals.map((goal) => [
+                goal.start,
+                goal.target,
+                goal.name,
+                goal.description,
+            ]),
+            bucket_goal: data.bucketGoals.map((bucketGoal) => [
+                bucketGoal.start,
+                bucketGoal.goal,
+            ]),
+        });
+
+        payload.records.push({
+            def: definitionIndex,
+            sha: data.recSha,
+            source: data.source,
+            source_key: data.sourceKey,
+            point_hit: data.pointHits.map((pointHit) => [
+                pointHit.start,
+                pointHit.depth,
+                pointHit.hits,
+                pointHit.hit_buckets,
+                pointHit.full_buckets,
+            ]),
+            bucket_hit: data.bucketHits.map((bucketHit) => [
+                bucketHit.start,
+                bucketHit.hits,
+            ]),
+        });
+    }
+
+    return new TextEncoder().encode(JSON.stringify(payload));
+}
+
+export function serializeReadoutsToArchiveBytes(readouts: Readout[]): Uint8Array {
+    const pointTable = new CsvTableBuilder();
+    const axisTable = new CsvTableBuilder();
+    const axisValueTable = new CsvTableBuilder();
+    const goalTable = new CsvTableBuilder();
+    const bucketGoalTable = new CsvTableBuilder();
+    const pointHitTable = new CsvTableBuilder();
+    const bucketHitTable = new CsvTableBuilder();
+    const definitionTable = new CsvTableBuilder();
+    const recordTable = new CsvTableBuilder();
+
+    for (const readout of readouts) {
+        const data = materializeReadout(readout);
+
+        const pointSpan = pointTable.writeRows(
+            data.points.map((point) => [
+                point.start,
+                point.depth,
+                point.end,
+                point.axis_start,
+                point.axis_end,
+                point.axis_value_start,
+                point.axis_value_end,
+                point.goal_start,
+                point.goal_end,
+                point.bucket_start,
+                point.bucket_end,
+                point.target,
+                point.target_buckets,
+                point.name,
+                point.description,
+            ]),
+        );
+
+        const pointHitSpan = pointHitTable.writeRows(
+            data.pointHits.map((pointHit) => [
+                pointHit.start,
+                pointHit.depth,
+                pointHit.hits,
+                pointHit.hit_buckets,
+                pointHit.full_buckets,
+            ]),
+        );
+
+        const axisSpan = axisTable.writeRows(
+            data.axes.map((axis) => [
+                axis.value_start,
+                axis.value_end,
+                axis.name,
+                axis.description,
+            ]),
+        );
+
+        const axisValueSpan = axisValueTable.writeRows(
+            data.axisValues.map((axisValue) => [axisValue.value]),
+        );
+
+        const goalSpan = goalTable.writeRows(
+            data.goals.map((goal) => [goal.target, goal.name, goal.description]),
+        );
+
+        const bucketGoalSpan = bucketGoalTable.writeRows(
+            data.bucketGoals.map((bucketGoal) => [bucketGoal.goal]),
+        );
+
+        const bucketHitSpan = bucketHitTable.writeRows(
+            data.bucketHits.map((bucketHit) => [bucketHit.hits]),
+        );
+
+        const definitionSpan = definitionTable.writeRows([
+            [
+                data.defSha,
+                pointSpan.start,
+                pointSpan.end,
+                axisSpan.start,
+                axisSpan.end,
+                axisValueSpan.start,
+                axisValueSpan.end,
+                goalSpan.start,
+                goalSpan.end,
+                bucketGoalSpan.start,
+                bucketGoalSpan.end,
+            ],
+        ]);
+
+        recordTable.writeRows([
+            [
+                data.recSha,
+                definitionSpan.start,
+                pointHitSpan.start,
+                pointHitSpan.end,
+                bucketHitSpan.start,
+                bucketHitSpan.end,
+                data.source ?? "",
+                data.sourceKey ?? "",
+            ],
+        ]);
+    }
+
+    const tarBytes = createTar([
+        { name: "definition", data: definitionTable.toBytes() },
+        { name: "record", data: recordTable.toBytes() },
+        { name: "point", data: pointTable.toBytes() },
+        { name: "axis", data: axisTable.toBytes() },
+        { name: "axis_value", data: axisValueTable.toBytes() },
+        { name: "goal", data: goalTable.toBytes() },
+        { name: "bucket_goal", data: bucketGoalTable.toBytes() },
+        { name: "point_hit", data: pointHitTable.toBytes() },
+        { name: "bucket_hit", data: bucketHitTable.toBytes() },
+    ]);
+
+    return gzipSync(tarBytes);
+}
+
+export function serializeReadouts(readouts: Readout[], format: ExportFormat): Uint8Array {
+    return format === "json"
+        ? serializeReadoutsToJsonBytes(readouts)
+        : serializeReadoutsToArchiveBytes(readouts);
+}

--- a/viewer/src/services/fileLoader.ts
+++ b/viewer/src/services/fileLoader.ts
@@ -3,8 +3,7 @@
  * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
  */
 
-import { readFileHandle, readElectronFile } from "@/features/Dashboard/lib/readers";
-import CoverageTree from "@/features/Dashboard/lib/coveragetree";
+import { readFileHandle, readElectronFile } from "../features/Dashboard/lib/readers";
 
 /**
  * Check if we're running in Electron
@@ -14,41 +13,36 @@ export function isElectron(): boolean {
 }
 
 /**
- * Load a file from bytes and return a CoverageTree
+ * Load readouts from bytes
  */
-export async function loadFileFromBytes(bytes: number[]): Promise<CoverageTree> {
-    console.log('Loading file, bytes length:', bytes.length);
+export async function loadReadoutsFromBytes(bytes: number[]): Promise<Readout[]> {
     const reader = await readElectronFile(bytes);
-    console.log('Reader created, reading readouts...');
     const readouts: Readout[] = [];
     for await (const readout of reader.read_all()) {
         readouts.push(readout);
     }
-    console.log('Readouts loaded:', readouts.length);
     if (readouts.length === 0) {
         throw new Error('File loaded but contains no coverage data.');
     }
-    const newTree = CoverageTree.fromReadouts(readouts);
-    console.log('Tree created, roots:', newTree.getRoots().length);
-    return newTree;
+    return readouts;
 }
 
 /**
- * Load a file from a File object (web browser)
+ * Load readouts from a File object (web browser)
  */
-export async function loadFileFromFileObject(file: File): Promise<CoverageTree> {
+export async function loadReadoutsFromFileObject(file: File): Promise<Readout[]> {
     if (!file.name.endsWith('.bktgz')) {
         throw new Error('File must be a .bktgz file');
     }
     const arrayBuffer = await file.arrayBuffer();
     const bytes = Array.from(new Uint8Array(arrayBuffer));
-    return loadFileFromBytes(bytes);
+    return loadReadoutsFromBytes(bytes);
 }
 
 /**
- * Load a file from a FileSystemFileHandle (PWA file handling)
+ * Load readouts from a FileSystemFileHandle (PWA file handling)
  */
-export async function loadFileFromFileHandle(file: FileSystemFileHandle): Promise<CoverageTree> {
+export async function loadReadoutsFromFileHandle(file: FileSystemFileHandle): Promise<Readout[]> {
     const reader = await readFileHandle(file);
     const readouts: Readout[] = [];
     for await (const readout of reader.read_all()) {
@@ -57,23 +51,26 @@ export async function loadFileFromFileHandle(file: FileSystemFileHandle): Promis
     if (readouts.length === 0) {
         throw new Error('File loaded but contains no coverage data.');
     }
-    return CoverageTree.fromReadouts(readouts);
+    return readouts;
 }
 
 /**
- * Open file dialog in Electron and load the selected file(s)
- * Returns the first file's tree, or null if cancelled
+ * Open file dialog in Electron and return selected file path(s)
  */
-export async function openElectronFileDialog(): Promise<CoverageTree | null> {
+export async function openElectronFileDialog(): Promise<string[] | null> {
     if (!isElectron() || !window.electronAPI) {
         return null;
     }
-    const filePaths = await window.electronAPI.openFileDialog();
-    if (!filePaths || filePaths.length === 0) {
-        return null;
+    return window.electronAPI.openFileDialog();
+}
+
+/**
+ * Load readouts from an Electron file path
+ */
+export async function loadReadoutsFromElectronPath(filePath: string): Promise<Readout[]> {
+    if (!window.electronAPI) {
+        throw new Error("Electron API unavailable");
     }
-    // Load the first file (for now, single file support)
-    // TODO: Support multi-file loading
-    const bytes = await window.electronAPI.readFile(filePaths[0]);
-    return loadFileFromBytes(bytes);
+    const bytes = await window.electronAPI.readFile(filePath);
+    return loadReadoutsFromBytes(bytes);
 }

--- a/viewer/src/services/readoutUtils.ts
+++ b/viewer/src/services/readoutUtils.ts
@@ -1,0 +1,284 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+ */
+
+type MaterializedReadoutData = {
+    defSha: string;
+    recSha: string;
+    source: string | null;
+    sourceKey: string | null;
+    points: PointTuple[];
+    bucketGoals: BucketGoalTuple[];
+    axes: AxisTuple[];
+    axisValues: AxisValueTuple[];
+    goals: GoalTuple[];
+    pointHits: PointHitTuple[];
+    bucketHits: BucketHitTuple[];
+};
+
+function clonePointTuple(point: PointTuple): PointTuple {
+    return { ...point };
+}
+
+function cloneBucketGoalTuple(bucketGoal: BucketGoalTuple): BucketGoalTuple {
+    return { ...bucketGoal };
+}
+
+function cloneAxisTuple(axis: AxisTuple): AxisTuple {
+    return { ...axis };
+}
+
+function cloneAxisValueTuple(axisValue: AxisValueTuple): AxisValueTuple {
+    return { ...axisValue };
+}
+
+function cloneGoalTuple(goal: GoalTuple): GoalTuple {
+    return { ...goal };
+}
+
+function clonePointHitTuple(pointHit: PointHitTuple): PointHitTuple {
+    return { ...pointHit };
+}
+
+function cloneBucketHitTuple(bucketHit: BucketHitTuple): BucketHitTuple {
+    return { ...bucketHit };
+}
+
+function toSliceEnd<T>(items: T[], end: number | null): number {
+    return end === null ? items.length : end;
+}
+
+export class InMemoryReadout implements Readout {
+    private data: MaterializedReadoutData;
+
+    constructor(data: MaterializedReadoutData) {
+        this.data = data;
+    }
+
+    get_def_sha(): string {
+        return this.data.defSha;
+    }
+
+    get_rec_sha(): string {
+        return this.data.recSha;
+    }
+
+    get_source(): string | null {
+        return this.data.source;
+    }
+
+    get_source_key(): string | null {
+        return this.data.sourceKey;
+    }
+
+    *iter_points(
+        start: number = 0,
+        end: number | null = null,
+        depth: number = 0,
+    ): Generator<PointTuple> {
+        const offsetStart = start + depth;
+        const offsetEnd = end === null ? null : end + depth;
+        yield* this.data.points
+            .slice(offsetStart, toSliceEnd(this.data.points, offsetEnd))
+            .map(clonePointTuple);
+    }
+
+    *iter_bucket_goals(
+        start: number = 0,
+        end: number | null = null,
+    ): Generator<BucketGoalTuple> {
+        yield* this.data.bucketGoals
+            .slice(start, toSliceEnd(this.data.bucketGoals, end))
+            .map(cloneBucketGoalTuple);
+    }
+
+    *iter_axes(start: number = 0, end: number | null = null): Generator<AxisTuple> {
+        yield* this.data.axes
+            .slice(start, toSliceEnd(this.data.axes, end))
+            .map(cloneAxisTuple);
+    }
+
+    *iter_axis_values(
+        start: number = 0,
+        end: number | null = null,
+    ): Generator<AxisValueTuple> {
+        yield* this.data.axisValues
+            .slice(start, toSliceEnd(this.data.axisValues, end))
+            .map(cloneAxisValueTuple);
+    }
+
+    *iter_goals(start: number = 0, end: number | null = null): Generator<GoalTuple> {
+        yield* this.data.goals
+            .slice(start, toSliceEnd(this.data.goals, end))
+            .map(cloneGoalTuple);
+    }
+
+    *iter_point_hits(
+        start: number = 0,
+        end: number | null = null,
+        depth: number = 0,
+    ): Generator<PointHitTuple> {
+        const offsetStart = start + depth;
+        const offsetEnd = end === null ? null : end + depth;
+        yield* this.data.pointHits
+            .slice(offsetStart, toSliceEnd(this.data.pointHits, offsetEnd))
+            .map(clonePointHitTuple);
+    }
+
+    *iter_bucket_hits(
+        start: number = 0,
+        end: number | null = null,
+    ): Generator<BucketHitTuple> {
+        yield* this.data.bucketHits
+            .slice(start, toSliceEnd(this.data.bucketHits, end))
+            .map(cloneBucketHitTuple);
+    }
+}
+
+export function materializeReadout(readout: Readout): MaterializedReadoutData {
+    return {
+        defSha: readout.get_def_sha(),
+        recSha: readout.get_rec_sha(),
+        source: readout.get_source(),
+        sourceKey: readout.get_source_key(),
+        points: Array.from(readout.iter_points()).map(clonePointTuple),
+        bucketGoals: Array.from(readout.iter_bucket_goals(0, null)).map(cloneBucketGoalTuple),
+        axes: Array.from(readout.iter_axes(0, null)).map(cloneAxisTuple),
+        axisValues: Array.from(readout.iter_axis_values(0, null)).map(cloneAxisValueTuple),
+        goals: Array.from(readout.iter_goals(0, null)).map(cloneGoalTuple),
+        pointHits: Array.from(readout.iter_point_hits()).map(clonePointHitTuple),
+        bucketHits: Array.from(readout.iter_bucket_hits(0, null)).map(cloneBucketHitTuple),
+    };
+}
+
+function getMergedSourceName(): string {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    const hour = String(now.getHours()).padStart(2, "0");
+    const minute = String(now.getMinutes()).padStart(2, "0");
+    const second = String(now.getSeconds()).padStart(2, "0");
+    return `Merged_${year}${month}${day}_${hour}${minute}${second}`;
+}
+
+function buildMergedPointHits(
+    points: PointTuple[],
+    bucketGoals: BucketGoalTuple[],
+    goals: GoalTuple[],
+    bucketHits: BucketHitTuple[],
+): PointHitTuple[] {
+    const goalTargetByStart = new Map<number, number>();
+    for (const goal of goals) {
+        goalTargetByStart.set(goal.start, goal.target);
+    }
+
+    const bucketGoalByStart = new Map<number, BucketGoalTuple>();
+    for (const bucketGoal of bucketGoals) {
+        bucketGoalByStart.set(bucketGoal.start, bucketGoal);
+    }
+
+    const bucketHitByStart = new Map<number, BucketHitTuple>();
+    for (const bucketHit of bucketHits) {
+        bucketHitByStart.set(bucketHit.start, bucketHit);
+    }
+
+    const pointHits: PointHitTuple[] = [];
+    for (const point of points) {
+        let hits = 0;
+        let hitBuckets = 0;
+        let fullBuckets = 0;
+        for (let bucketIdx = point.bucket_start; bucketIdx < point.bucket_end; bucketIdx += 1) {
+            const bucketHit = bucketHitByStart.get(bucketIdx);
+            if (!bucketHit) {
+                continue;
+            }
+            const bucketGoal = bucketGoalByStart.get(bucketIdx);
+            if (!bucketGoal) {
+                continue;
+            }
+            const target = goalTargetByStart.get(bucketGoal.goal) ?? 0;
+            if (target <= 0) {
+                continue;
+            }
+            const cappedBucketHits = Math.min(bucketHit.hits, target);
+            if (bucketHit.hits > 0) {
+                hitBuckets += 1;
+                if (cappedBucketHits >= target) {
+                    fullBuckets += 1;
+                }
+                hits += cappedBucketHits;
+            }
+        }
+        pointHits.push({
+            start: point.start,
+            depth: point.depth,
+            hits,
+            hit_buckets: hitBuckets,
+            full_buckets: fullBuckets,
+        });
+    }
+    return pointHits;
+}
+
+export function mergeReadoutsStrict(readouts: Readout[]): Readout {
+    if (readouts.length === 0) {
+        throw new Error("No records selected for merge.");
+    }
+
+    const [masterReadout, ...otherReadouts] = readouts;
+    const master = materializeReadout(masterReadout);
+
+    const hitsByBucketStart = new Map<number, number>();
+    for (const bucketHit of master.bucketHits) {
+        hitsByBucketStart.set(bucketHit.start, bucketHit.hits);
+    }
+
+    for (const readout of otherReadouts) {
+        if (readout.get_def_sha() !== master.defSha) {
+            throw new Error("Tried to merge coverage with two different definition hashes!");
+        }
+        if (readout.get_rec_sha() !== master.recSha) {
+            throw new Error("Tried to merge coverage with two different record hashes!");
+        }
+
+        for (const bucketHit of readout.iter_bucket_hits(0, null)) {
+            if (!hitsByBucketStart.has(bucketHit.start)) {
+                throw new Error(
+                    `Record has unexpected bucket index ${bucketHit.start}; merge aborted.`,
+                );
+            }
+            hitsByBucketStart.set(
+                bucketHit.start,
+                (hitsByBucketStart.get(bucketHit.start) ?? 0) + bucketHit.hits,
+            );
+        }
+    }
+
+    const mergedBucketHits = master.bucketHits.map((bucketHit) => ({
+        ...bucketHit,
+        hits: hitsByBucketStart.get(bucketHit.start) ?? bucketHit.hits,
+    }));
+
+    const mergedPointHits = buildMergedPointHits(
+        master.points,
+        master.bucketGoals,
+        master.goals,
+        mergedBucketHits,
+    );
+
+    return new InMemoryReadout({
+        defSha: master.defSha,
+        recSha: master.recSha,
+        source: getMergedSourceName(),
+        sourceKey: "",
+        points: master.points,
+        bucketGoals: master.bucketGoals,
+        axes: master.axes,
+        axisValues: master.axisValues,
+        goals: master.goals,
+        pointHits: mergedPointHits,
+        bucketHits: mergedBucketHits,
+    });
+}

--- a/viewer/src/types/coverageSession.ts
+++ b/viewer/src/types/coverageSession.ts
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+ */
+
+export type CoverageSourceKind =
+    | "electronPath"
+    | "fileHandle"
+    | "fileObject"
+    | "virtualMerged";
+
+export type CoverageSourceRef = {
+    id: string;
+    kind: CoverageSourceKind;
+    label: string;
+    path?: string;
+    fileHandle?: FileSystemFileHandle;
+    fileObject?: File;
+};
+
+export type CoverageRecord = {
+    id: string;
+    readout: Readout;
+    sourceRef: string;
+    sourceRecordIndex: number;
+    isLoaded: boolean;
+};
+
+export type CoverageSession = {
+    records: CoverageRecord[];
+    sources: CoverageSourceRef[];
+    loadedRecordIds: string[];
+};
+
+export type ExportFormat = "bktgz" | "json";

--- a/viewer/src/vite-env.d.ts
+++ b/viewer/src/vite-env.d.ts
@@ -14,6 +14,11 @@ interface ElectronAPI {
   openFileDialog: () => Promise<string[] | null>;
   readFile: (filePath: string) => Promise<number[]>;
   getDroppedFile: (filePath: string) => Promise<number[] | null>;
+  saveExportFile: (payload: {
+    bytes: number[];
+    format: "bktgz" | "json";
+    defaultFileName: string;
+  }) => Promise<{ canceled: boolean; path?: string }>;
   onFilesOpened: (callback: (filePaths: string[]) => void) => void;
   onClearCoverage: (callback: () => void) => void;
 }


### PR DESCRIPTION
- Implemented a new IPC handler for saving export files in various formats (JSON and BKTGZ).
- Updated the preload script to expose the saveExportFile API to the renderer.
- Enhanced the Dashboard component to support exporting records with a new onExportRecords prop.
- Created utility functions for file saving and serialization of coverage data.
- Added tests for the export serializers to ensure correct functionality.
- Refresh button for Electron app (as it is aware of the file paths loaded)

<img width="904" height="398" alt="Screenshot 2026-04-05 at 22 43 33" src="https://github.com/user-attachments/assets/0add981a-bdc4-459c-8fcd-7c61f8df80e3" />
<img width="520" height="388" alt="Screenshot 2026-04-05 at 22 48 03" src="https://github.com/user-attachments/assets/cc4b4c84-34ba-4eda-8f34-eed1b1c68e0c" />
