### PR TITLE
[None] Enforce release prefixes and automate versioning for releases

### DIFF
--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -66,7 +66,7 @@ jobs:
           ref: main
 
       - name: Set up Python
-        if: steps.pr_meta.outputs.bump != 'none'
+        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
@@ -74,12 +74,6 @@ jobs:
       - name: Bump version files
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
         run: python scripts/bump_version.py --bump "${{ steps.pr_meta.outputs.bump }}"
-
-      - name: Checkout merged commit for force mode
-        if: steps.pr_meta.outputs.bump == 'force'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Commit and push bump commit
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
@@ -107,41 +101,96 @@ jobs:
           git commit -m "chore: bump version (${BUMP_KIND})"
           git push origin HEAD:main
 
-      - name: Resolve release target SHA
-        if: steps.pr_meta.outputs.bump != 'none'
-        id: release_target
+      - name: Resolve release target SHA for automatic bump
+        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
+        id: release_target_auto
         run: |
           set -euo pipefail
           TARGET_SHA="$(git rev-parse HEAD)"
           echo "sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
           echo "Release target SHA: ${TARGET_SHA}"
 
+      - name: Resolve release target SHA for force mode
+        if: steps.pr_meta.outputs.bump == 'force'
+        id: release_target_force
+        env:
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          echo "sha=${MERGE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Release target SHA: ${MERGE_SHA}"
+
       - name: Derive release tag from pyproject version
         if: steps.pr_meta.outputs.bump != 'none'
         id: version_meta
-        run: |
-          set -euo pipefail
+        env:
+          TARGET_SHA: ${{ steps.release_target_auto.outputs.sha || steps.release_target_force.outputs.sha }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const targetSha = process.env.TARGET_SHA;
+            const { owner, repo } = context.repo;
 
-          VERSION="$(python - <<'PY'
-          from pathlib import Path
-          import tomllib
+            if (!targetSha) {
+              core.setFailed("Missing release target SHA.");
+              return;
+            }
 
-          payload = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
-          print(str(payload["project"]["version"]))
-          PY
-          )"
+            const response = await github.rest.repos.getContent({
+              owner,
+              repo,
+              path: "pyproject.toml",
+              ref: targetSha,
+            });
 
-          TAG="v${VERSION}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Release tag will be ${TAG}"
+            if (Array.isArray(response.data)) {
+              core.setFailed("pyproject.toml resolved to a directory.");
+              return;
+            }
+
+            const text = Buffer.from(
+              response.data.content,
+              response.data.encoding,
+            ).toString("utf8");
+
+            const lines = text.split(/\r?\n/);
+            let inProjectSection = false;
+            let version = null;
+
+            for (const line of lines) {
+              const section = line.match(/^\s*\[([^\]]+)\]\s*$/);
+              if (section) {
+                inProjectSection = section[1] === "project";
+                continue;
+              }
+              if (!inProjectSection) {
+                continue;
+              }
+              const match = line.match(/^\s*version\s*=\s*"([^"]+)"\s*$/);
+              if (match) {
+                version = match[1];
+                break;
+              }
+            }
+
+            if (!version) {
+              core.setFailed(
+                `Could not find [project].version in pyproject.toml at ${targetSha}.`,
+              );
+              return;
+            }
+
+            const tag = `v${version}`;
+            core.setOutput("version", version);
+            core.setOutput("tag", tag);
+            core.info(`Release tag will be ${tag}`);
 
       - name: Create GitHub release with generated notes
         if: steps.pr_meta.outputs.bump != 'none'
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.version_meta.outputs.tag }}
-          TARGET_SHA: ${{ steps.release_target.outputs.sha }}
+          TARGET_SHA: ${{ steps.release_target_auto.outputs.sha || steps.release_target_force.outputs.sha }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -29,35 +29,35 @@ jobs:
           set -euo pipefail
 
           case "$PR_TITLE" in
-            Patch:*)
+            \[Patch\]*)
               echo "bump=patch" >> "$GITHUB_OUTPUT"
               ;;
-            Minor:*)
+            \[Minor\]*)
               echo "bump=minor" >> "$GITHUB_OUTPUT"
               ;;
-            Major:*)
+            \[Major\]*)
               echo "bump=major" >> "$GITHUB_OUTPUT"
               ;;
-            None:*)
+            \[None\]*)
               echo "bump=none" >> "$GITHUB_OUTPUT"
               ;;
-            Force:*)
+            \[Force\]*)
               echo "bump=force" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "Unsupported PR title prefix: '$PR_TITLE'"
-              echo "Expected one of: Patch:, Minor:, Major:, None:, Force:"
+              echo "Expected one of: [Patch], [Minor], [Major], [None], [Force]"
               exit 1
               ;;
           esac
 
       - name: No version bump needed
         if: steps.pr_meta.outputs.bump == 'none'
-        run: echo "PR title starts with None:. Skipping version bump, tag, and release."
+        run: echo "PR title starts with [None]. Skipping version bump, tag, and release."
 
       - name: Force mode notice
         if: steps.pr_meta.outputs.bump == 'force'
-        run: echo "PR title starts with Force:. Skipping auto-bump and using merged commit version for tag/release."
+        run: echo "PR title starts with [Force]. Skipping auto-bump and using merged commit version for tag/release."
 
       - name: Checkout main for automated bump
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)

--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+name: Bump Version On Merge
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: version-bump-main
+  cancel-in-progress: false
+
+jobs:
+  bump-version:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Derive bump type from PR title
+        id: pr_meta
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          case "$PR_TITLE" in
+            Patch:*)
+              echo "bump=patch" >> "$GITHUB_OUTPUT"
+              ;;
+            Minor:*)
+              echo "bump=minor" >> "$GITHUB_OUTPUT"
+              ;;
+            Major:*)
+              echo "bump=major" >> "$GITHUB_OUTPUT"
+              ;;
+            None:*)
+              echo "bump=none" >> "$GITHUB_OUTPUT"
+              ;;
+            Force:*)
+              echo "bump=force" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unsupported PR title prefix: '$PR_TITLE'"
+              echo "Expected one of: Patch:, Minor:, Major:, None:, Force:"
+              exit 1
+              ;;
+          esac
+
+      - name: No version bump needed
+        if: steps.pr_meta.outputs.bump == 'none'
+        run: echo "PR title starts with None:. Skipping version bump, tag, and release."
+
+      - name: Force mode notice
+        if: steps.pr_meta.outputs.bump == 'force'
+        run: echo "PR title starts with Force:. Skipping auto-bump and using merged commit version for tag/release."
+
+      - name: Checkout main for automated bump
+        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Set up Python
+        if: steps.pr_meta.outputs.bump != 'none'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Bump version files
+        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
+        run: python scripts/bump_version.py --bump "${{ steps.pr_meta.outputs.bump }}"
+
+      - name: Checkout merged commit for force mode
+        if: steps.pr_meta.outputs.bump == 'force'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Commit and push bump commit
+        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
+        env:
+          BUMP_KIND: ${{ steps.pr_meta.outputs.bump }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git diff --quiet; then
+            echo "No version file changes detected."
+            exit 0
+          fi
+
+          git add pyproject.toml
+          if [ -f electron/package.json ]; then
+            git add electron/package.json
+          fi
+          if [ -f viewer/package.json ]; then
+            git add viewer/package.json
+          fi
+
+          git commit -m "chore: bump version (${BUMP_KIND})"
+          git push origin HEAD:main
+
+      - name: Resolve release target SHA
+        if: steps.pr_meta.outputs.bump != 'none'
+        id: release_target
+        run: |
+          set -euo pipefail
+          TARGET_SHA="$(git rev-parse HEAD)"
+          echo "sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Release target SHA: ${TARGET_SHA}"
+
+      - name: Derive release tag from pyproject version
+        if: steps.pr_meta.outputs.bump != 'none'
+        id: version_meta
+        run: |
+          set -euo pipefail
+
+          VERSION="$(python - <<'PY'
+          from pathlib import Path
+          import tomllib
+
+          payload = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+          print(str(payload["project"]["version"]))
+          PY
+          )"
+
+          TAG="v${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Release tag will be ${TAG}"
+
+      - name: Create GitHub release with generated notes
+        if: steps.pr_meta.outputs.bump != 'none'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version_meta.outputs.tag }}
+          TARGET_SHA: ${{ steps.release_target.outputs.sha }}
+        run: |
+          set -euo pipefail
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release ${RELEASE_TAG} already exists. Skipping create."
+            exit 0
+          fi
+
+          gh release create "$RELEASE_TAG" \
+            --target "$TARGET_SHA" \
+            --title "$RELEASE_TAG" \
+            --generate-notes

--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -59,6 +59,11 @@ jobs:
         if: steps.pr_meta.outputs.bump == 'force'
         run: echo "PR title starts with [Force]. Skipping auto-bump and using merged commit version for tag/release."
 
+      # Intentional tradeoff:
+      # This checks out the current tip of main (not merge_commit_sha) for automatic
+      # patch/minor/major bumps. If other PRs merge before this job runs, the bump
+      # commit and generated release notes may include those adjacent merges too.
+      # We accept this for a simpler workflow in a low-throughput repository.
       - name: Checkout main for automated bump
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
         uses: actions/checkout@v4

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -5,6 +5,7 @@ name: PR Title Check
 
 on:
   pull_request:
+    branches: [main]
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
 permissions:
@@ -118,6 +119,7 @@ jobs:
             ];
 
             const changedVersions = [];
+            const missingRequiredFiles = [];
 
             for (const file of files) {
               const baseText = await readTextFile(baseOwner, baseRepo, file.path, baseRef);
@@ -125,7 +127,7 @@ jobs:
 
               if (baseText === null || headText === null) {
                 const missingSide = baseText === null ? "base" : "head";
-                changedVersions.push(`${file.path}: file missing in ${missingSide} ref`);
+                missingRequiredFiles.push(`${file.path}: missing in ${missingSide} ref`);
                 continue;
               }
 
@@ -135,6 +137,22 @@ jobs:
               if (baseVersion !== headVersion) {
                 changedVersions.push(`${file.path}: ${baseVersion} -> ${headVersion}`);
               }
+            }
+
+            if (missingRequiredFiles.length > 0) {
+              core.setFailed(
+                [
+                  "Required version files are missing in this PR comparison.",
+                  "",
+                  "What to do:",
+                  "1. Ensure pyproject.toml, viewer/package.json, and electron/package.json all exist.",
+                  "2. Restore any deleted/missing required file before merging.",
+                  "",
+                  "Missing required files:",
+                  ...missingRequiredFiles.map((line) => `- ${line}`),
+                ].join("\n"),
+              );
+              return;
             }
 
             if (changedVersions.length > 0) {
@@ -169,16 +187,23 @@ jobs:
             const headRepo = pr.head.repo.name;
 
             async function readTextFile(owner, repo, path, ref) {
-              const response = await github.rest.repos.getContent({
-                owner,
-                repo,
-                path,
-                ref,
-              });
-              if (Array.isArray(response.data)) {
-                throw new Error(`${path} is a directory, expected a file`);
+              try {
+                const response = await github.rest.repos.getContent({
+                  owner,
+                  repo,
+                  path,
+                  ref,
+                });
+                if (Array.isArray(response.data)) {
+                  throw new Error(`${path} is a directory, expected a file`);
+                }
+                return Buffer.from(response.data.content, response.data.encoding).toString("utf8");
+              } catch (error) {
+                if (error.status === 404) {
+                  return null;
+                }
+                throw error;
               }
-              return Buffer.from(response.data.content, response.data.encoding).toString("utf8");
             }
 
             function getPyprojectVersion(text) {
@@ -215,21 +240,43 @@ jobs:
               { path: "electron/package.json", parser: getPackageVersion },
             ];
 
-            const baseVersions = {};
             const headVersions = {};
             const changedVersions = [];
+            const missingRequiredFiles = [];
 
             for (const file of files) {
               const baseText = await readTextFile(baseOwner, baseRepo, file.path, baseRef);
               const headText = await readTextFile(headOwner, headRepo, file.path, headRef);
+
+              if (baseText === null || headText === null) {
+                const missingSide = baseText === null ? "base" : "head";
+                missingRequiredFiles.push(`${file.path}: missing in ${missingSide} ref`);
+                continue;
+              }
+
               const baseVersion = file.parser(baseText, file.path);
               const headVersion = file.parser(headText, file.path);
-              baseVersions[file.path] = baseVersion;
               headVersions[file.path] = headVersion;
 
               if (baseVersion !== headVersion) {
                 changedVersions.push(`${file.path}: ${baseVersion} -> ${headVersion}`);
               }
+            }
+
+            if (missingRequiredFiles.length > 0) {
+              core.setFailed(
+                [
+                  "[Force] requires all version files to exist in both base and head refs.",
+                  "",
+                  "What to do:",
+                  "1. Ensure pyproject.toml, viewer/package.json, and electron/package.json all exist.",
+                  "2. Restore any missing required file before merging.",
+                  "",
+                  "Missing required files:",
+                  ...missingRequiredFiles.map((line) => `- ${line}`),
+                ].join("\n"),
+              );
+              return;
             }
 
             if (changedVersions.length === 0) {

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -22,11 +22,11 @@ jobs:
           set -euo pipefail
 
           case "$PR_TITLE" in
-            Patch:*|Minor:*|Major:*|None:*|Force:*)
+            \[Patch\]*|\[Minor\]*|\[Major\]*|\[None\]*|\[Force\]*)
               echo "PR title prefix is valid."
               ;;
             *)
-              echo "::error title=Invalid PR title prefix::PR title must start with one of: Patch:, Minor:, Major:, None:, Force:"
+              echo "::error title=Invalid PR title prefix::PR title must start with one of: [Patch], [Minor], [Major], [None], [Force]"
               echo "Invalid PR title: '$PR_TITLE'"
               echo ""
               echo "How to fix:"
@@ -34,24 +34,24 @@ jobs:
               echo "2. Add one of the required prefixes followed by a short description."
               echo ""
               echo "Prefix meanings:"
-              echo "Patch: Backward-compatible bug fix or small correction (bump patch; create tag/release)."
-              echo "Minor: Backward-compatible feature/improvement (bump minor; create tag/release)."
-              echo "Major: Breaking change (bump major; create tag/release)."
-              echo "None: No release-impacting change (no version bump, no tag, no release)."
-              echo "Force: Manual release mode (no auto bump; requires version change; allow version-file edits; create tag/release)."
+              echo "[Patch] Backward-compatible bug fix or small correction (bump patch; create tag/release)."
+              echo "[Minor] Backward-compatible feature/improvement (bump minor; create tag/release)."
+              echo "[Major] Breaking change (bump major; create tag/release)."
+              echo "[None] No release-impacting change (no version bump, no tag, no release)."
+              echo "[Force] Manual release mode (no auto bump; requires version change; allow version-file edits; create tag/release)."
               echo ""
               echo "Examples:"
-              echo "Patch: fix crash when loading archive"
-              echo "Minor: add CSV import filters"
-              echo "Major: remove legacy JSON schema"
-              echo "None: docs cleanup for coverage guide"
-              echo "Force: release v2.3.0 with manual version update"
+              echo "[Patch] fix crash when loading archive"
+              echo "[Minor] add CSV import filters"
+              echo "[Major] remove legacy JSON schema"
+              echo "[None] docs cleanup for coverage guide"
+              echo "[Force] release v2.3.0 with manual version update"
               exit 1
               ;;
           esac
 
       - name: Block manual version changes in PRs
-        if: ${{ !startsWith(github.event.pull_request.title, 'Force:') }}
+        if: ${{ !startsWith(github.event.pull_request.title, '[Force]') }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -145,7 +145,7 @@ jobs:
                   "",
                   "What to do:",
                   "1. Revert version field edits in pyproject.toml, viewer/package.json, and electron/package.json.",
-                  "2. Keep your PR title prefix as Patch:/Minor:/Major:/None: for automated versioning, or use Force: for manual versioning + release.",
+                  "2. Keep your PR title prefix as [Patch]/[Minor]/[Major]/[None] for automated versioning, or use [Force] for manual versioning + release.",
                   "",
                   "Detected manual version changes:",
                   ...changedVersions.map((line) => `- ${line}`),
@@ -156,7 +156,7 @@ jobs:
             }
 
       - name: Force mode requires manual version change
-        if: ${{ startsWith(github.event.pull_request.title, 'Force:') }}
+        if: ${{ startsWith(github.event.pull_request.title, '[Force]') }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -235,13 +235,13 @@ jobs:
             if (changedVersions.length === 0) {
               core.setFailed(
                 [
-                  "Force: requires a manual version change compared to main.",
+                  "[Force] requires a manual version change compared to main.",
                   "No tracked version values changed in this PR.",
                   "",
                   "What to do:",
                   "1. Update version fields in pyproject.toml, viewer/package.json, and electron/package.json.",
                   "2. Keep those version values aligned to the same X.Y.Z.",
-                  "3. Keep the PR title prefix as Force: for manual release mode.",
+                  "3. Keep the PR title prefix as [Force] for manual release mode.",
                 ].join("\n"),
               );
               return;
@@ -251,7 +251,7 @@ jobs:
             if (uniqueHeadVersions.length !== 1) {
               core.setFailed(
                 [
-                  "Force: requires synchronized version values.",
+                  "[Force] requires synchronized version values.",
                   "Tracked version files do not all match after your changes.",
                   "",
                   "Current head versions:",
@@ -264,4 +264,4 @@ jobs:
               return;
             }
 
-            core.info("Force: manual version change detected and version files are synchronized.");
+            core.info("[Force] manual version change detected and version files are synchronized.");

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  enforce-title-prefix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title prefix
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          case "$PR_TITLE" in
+            Patch:*|Minor:*|Major:*|None:*|Force:*)
+              echo "PR title prefix is valid."
+              ;;
+            *)
+              echo "::error title=Invalid PR title prefix::PR title must start with one of: Patch:, Minor:, Major:, None:, Force:"
+              echo "Invalid PR title: '$PR_TITLE'"
+              echo ""
+              echo "How to fix:"
+              echo "1. Edit the PR title in GitHub."
+              echo "2. Add one of the required prefixes followed by a short description."
+              echo ""
+              echo "Prefix meanings:"
+              echo "Patch: Backward-compatible bug fix or small correction (bump patch; create tag/release)."
+              echo "Minor: Backward-compatible feature/improvement (bump minor; create tag/release)."
+              echo "Major: Breaking change (bump major; create tag/release)."
+              echo "None: No release-impacting change (no version bump, no tag, no release)."
+              echo "Force: Manual release mode (no auto bump; requires version change; allow version-file edits; create tag/release)."
+              echo ""
+              echo "Examples:"
+              echo "Patch: fix crash when loading archive"
+              echo "Minor: add CSV import filters"
+              echo "Major: remove legacy JSON schema"
+              echo "None: docs cleanup for coverage guide"
+              echo "Force: release v2.3.0 with manual version update"
+              exit 1
+              ;;
+          esac
+
+      - name: Block manual version changes in PRs
+        if: ${{ !startsWith(github.event.pull_request.title, 'Force:') }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const baseRef = pr.base.sha;
+            const headRef = pr.head.sha;
+            const baseOwner = pr.base.repo.owner.login;
+            const baseRepo = pr.base.repo.name;
+            const headOwner = pr.head.repo.owner.login;
+            const headRepo = pr.head.repo.name;
+
+            async function readTextFile(owner, repo, path, ref) {
+              try {
+                const response = await github.rest.repos.getContent({
+                  owner,
+                  repo,
+                  path,
+                  ref,
+                });
+                if (Array.isArray(response.data)) {
+                  throw new Error(`${path} is a directory, expected a file`);
+                }
+                return Buffer.from(response.data.content, response.data.encoding).toString("utf8");
+              } catch (error) {
+                if (error.status === 404) {
+                  return null;
+                }
+                throw error;
+              }
+            }
+
+            function getPyprojectVersion(text) {
+              const lines = text.split(/\r?\n/);
+              let inProjectSection = false;
+              for (const line of lines) {
+                const section = line.match(/^\s*\[([^\]]+)\]\s*$/);
+                if (section) {
+                  inProjectSection = section[1] === "project";
+                  continue;
+                }
+                if (!inProjectSection) {
+                  continue;
+                }
+                const version = line.match(/^\s*version\s*=\s*"([^"]+)"\s*$/);
+                if (version) {
+                  return version[1];
+                }
+              }
+              throw new Error("Could not find [project].version in pyproject.toml");
+            }
+
+            function getPackageVersion(text, path) {
+              const parsed = JSON.parse(text);
+              if (typeof parsed.version !== "string") {
+                throw new Error(`Missing string \"version\" in ${path}`);
+              }
+              return parsed.version;
+            }
+
+            const files = [
+              { path: "pyproject.toml", parser: getPyprojectVersion },
+              { path: "viewer/package.json", parser: getPackageVersion },
+              { path: "electron/package.json", parser: getPackageVersion },
+            ];
+
+            const changedVersions = [];
+
+            for (const file of files) {
+              const baseText = await readTextFile(baseOwner, baseRepo, file.path, baseRef);
+              const headText = await readTextFile(headOwner, headRepo, file.path, headRef);
+
+              if (baseText === null || headText === null) {
+                const missingSide = baseText === null ? "base" : "head";
+                changedVersions.push(`${file.path}: file missing in ${missingSide} ref`);
+                continue;
+              }
+
+              const baseVersion = file.parser(baseText, file.path);
+              const headVersion = file.parser(headText, file.path);
+
+              if (baseVersion !== headVersion) {
+                changedVersions.push(`${file.path}: ${baseVersion} -> ${headVersion}`);
+              }
+            }
+
+            if (changedVersions.length > 0) {
+              core.setFailed(
+                [
+                  "Do not edit version numbers in PRs.",
+                  "Versioning is handled automatically when PRs merge to main using the PR title prefix.",
+                  "",
+                  "What to do:",
+                  "1. Revert version field edits in pyproject.toml, viewer/package.json, and electron/package.json.",
+                  "2. Keep your PR title prefix as Patch:/Minor:/Major:/None: for automated versioning, or use Force: for manual versioning + release.",
+                  "",
+                  "Detected manual version changes:",
+                  ...changedVersions.map((line) => `- ${line}`),
+                ].join("\n"),
+              );
+            } else {
+              core.info("No manual version changes detected in tracked version files.");
+            }
+
+      - name: Force mode requires manual version change
+        if: ${{ startsWith(github.event.pull_request.title, 'Force:') }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const baseRef = pr.base.sha;
+            const headRef = pr.head.sha;
+            const baseOwner = pr.base.repo.owner.login;
+            const baseRepo = pr.base.repo.name;
+            const headOwner = pr.head.repo.owner.login;
+            const headRepo = pr.head.repo.name;
+
+            async function readTextFile(owner, repo, path, ref) {
+              const response = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path,
+                ref,
+              });
+              if (Array.isArray(response.data)) {
+                throw new Error(`${path} is a directory, expected a file`);
+              }
+              return Buffer.from(response.data.content, response.data.encoding).toString("utf8");
+            }
+
+            function getPyprojectVersion(text) {
+              const lines = text.split(/\r?\n/);
+              let inProjectSection = false;
+              for (const line of lines) {
+                const section = line.match(/^\s*\[([^\]]+)\]\s*$/);
+                if (section) {
+                  inProjectSection = section[1] === "project";
+                  continue;
+                }
+                if (!inProjectSection) {
+                  continue;
+                }
+                const version = line.match(/^\s*version\s*=\s*"([^"]+)"\s*$/);
+                if (version) {
+                  return version[1];
+                }
+              }
+              throw new Error("Could not find [project].version in pyproject.toml");
+            }
+
+            function getPackageVersion(text, path) {
+              const parsed = JSON.parse(text);
+              if (typeof parsed.version !== "string") {
+                throw new Error(`Missing string \"version\" in ${path}`);
+              }
+              return parsed.version;
+            }
+
+            const files = [
+              { path: "pyproject.toml", parser: getPyprojectVersion },
+              { path: "viewer/package.json", parser: getPackageVersion },
+              { path: "electron/package.json", parser: getPackageVersion },
+            ];
+
+            const baseVersions = {};
+            const headVersions = {};
+            const changedVersions = [];
+
+            for (const file of files) {
+              const baseText = await readTextFile(baseOwner, baseRepo, file.path, baseRef);
+              const headText = await readTextFile(headOwner, headRepo, file.path, headRef);
+              const baseVersion = file.parser(baseText, file.path);
+              const headVersion = file.parser(headText, file.path);
+              baseVersions[file.path] = baseVersion;
+              headVersions[file.path] = headVersion;
+
+              if (baseVersion !== headVersion) {
+                changedVersions.push(`${file.path}: ${baseVersion} -> ${headVersion}`);
+              }
+            }
+
+            if (changedVersions.length === 0) {
+              core.setFailed(
+                [
+                  "Force: requires a manual version change compared to main.",
+                  "No tracked version values changed in this PR.",
+                  "",
+                  "What to do:",
+                  "1. Update version fields in pyproject.toml, viewer/package.json, and electron/package.json.",
+                  "2. Keep those version values aligned to the same X.Y.Z.",
+                  "3. Keep the PR title prefix as Force: for manual release mode.",
+                ].join("\n"),
+              );
+              return;
+            }
+
+            const uniqueHeadVersions = [...new Set(Object.values(headVersions))];
+            if (uniqueHeadVersions.length !== 1) {
+              core.setFailed(
+                [
+                  "Force: requires synchronized version values.",
+                  "Tracked version files do not all match after your changes.",
+                  "",
+                  "Current head versions:",
+                  ...Object.entries(headVersions).map(([path, version]) => `- ${path}: ${version}`),
+                  "",
+                  "What to do:",
+                  "1. Set pyproject.toml, viewer/package.json, and electron/package.json to the same version.",
+                ].join("\n"),
+              );
+              return;
+            }
+
+            core.info("Force: manual version change detected and version files are synchronized.");


### PR DESCRIPTION
This pull request adds two new GitHub Actions workflows to enforce and automate versioning based on pull request (PR) title prefixes. The first workflow (`pr-title-check.yml`) ensures all PRs use a required prefix and blocks manual version file edits unless in force mode. The second workflow (`bump-version-on-merge.yml`) automates version bumps, tagging, and release creation on merge to `main`, deriving the bump type from the PR title.

**PR title enforcement and validation:**

* Introduced `.github/workflows/pr-title-check.yml` to require PR titles to start with one of `[Patch]`, `[Minor]`, `[Major]`, `[None]`, or `[Force]`, providing guidance and blocking PRs with invalid prefixes.
* Blocks manual edits to `pyproject.toml`, `viewer/package.json`, and `electron/package.json` version fields in PRs unless `[Force]` mode is used, instructing users to revert such changes.
* In `[Force]` mode, enforces that a manual version change is present and that all version files are synchronized to the same value.

**Automated version bumping and release workflow:**

* Added `.github/workflows/bump-version-on-merge.yml` to automatically bump the appropriate version field(s), commit, tag, and create a GitHub release when a PR is merged to `main`, based on the PR title prefix.
* Supports `[None]` (no version bump/release) and `[Force]` (manual version change and release) modes, with clear logic for each.