### PR TITLE
[None] fix force PR title check runtime error

### DIFF
--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -10,7 +10,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: version-bump-main
@@ -59,11 +59,9 @@ jobs:
         if: steps.pr_meta.outputs.bump == 'force'
         run: echo "PR title starts with [Force]. Skipping auto-bump and using merged commit version for tag/release."
 
-      # Intentional tradeoff:
-      # This checks out the current tip of main (not merge_commit_sha) for automatic
-      # patch/minor/major bumps. If other PRs merge before this job runs, the bump
-      # commit and generated release notes may include those adjacent merges too.
-      # We accept this for a simpler workflow in a low-throughput repository.
+      # For automatic patch/minor/major bumps, create or update a release PR
+      # instead of pushing directly to main. This preserves branch protection
+      # and required status checks.
       - name: Checkout main for automated bump
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
         uses: actions/checkout@v4
@@ -80,40 +78,70 @@ jobs:
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
         run: python scripts/bump_version.py --bump "${{ steps.pr_meta.outputs.bump }}"
 
-      - name: Commit and push bump commit
+      - name: Read bumped version from pyproject.toml
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
+        id: bumped_version
+        run: |
+          set -euo pipefail
+          VERSION="$(python - <<'PY'
+          from pathlib import Path
+          import re
+
+          text = Path("pyproject.toml").read_text(encoding="utf-8")
+          section = re.search(r"(?ms)^\[project\]\r?\n(?P<body>.*?)(?=^\[|\Z)", text)
+          if not section:
+              raise SystemExit("Missing [project] section in pyproject.toml")
+
+          match = re.search(r'(?m)^version\s*=\s*"([^"]+)"\s*$', section.group("body"))
+          if not match:
+              raise SystemExit("Missing [project].version in pyproject.toml")
+
+          print(match.group(1))
+          PY
+          )"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Bumped version: ${VERSION}"
+
+      - name: Create or update force release PR
+        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
+        id: bump_pr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ github.token }}
+          base: main
+          branch: ci/version-bump-main
+          delete-branch: true
+          add-paths: |
+            pyproject.toml
+            electron/package.json
+            viewer/package.json
+          commit-message: "chore: bump version (${{ steps.pr_meta.outputs.bump }})"
+          title: "[Force] release v${{ steps.bumped_version.outputs.version }}"
+          body: |
+            Auto-generated version bump for a merged `${{ steps.pr_meta.outputs.bump }}` PR.
+
+            Source PR:
+            - #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}
+
+            This PR intentionally uses `[Force]` so manual version-file changes are allowed by repository checks.
+
+      - name: Enable auto-merge for bump PR
+        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump) && steps.bump_pr.outputs.pull-request-number != ''
         env:
-          BUMP_KIND: ${{ steps.pr_meta.outputs.bump }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.bump_pr.outputs.pull-request-number }}
         run: |
           set -euo pipefail
+          gh pr merge "$PR_NUMBER" --auto --squash || echo "Auto-merge could not be enabled automatically."
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          if git diff --quiet; then
-            echo "No version file changes detected."
-            exit 0
-          fi
-
-          git add pyproject.toml
-          if [ -f electron/package.json ]; then
-            git add electron/package.json
-          fi
-          if [ -f viewer/package.json ]; then
-            git add viewer/package.json
-          fi
-
-          git commit -m "chore: bump version (${BUMP_KIND})"
-          git push origin HEAD:main
-
-      - name: Resolve release target SHA for automatic bump
+      - name: Report bump PR
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
-        id: release_target_auto
         run: |
-          set -euo pipefail
-          TARGET_SHA="$(git rev-parse HEAD)"
-          echo "sha=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
-          echo "Release target SHA: ${TARGET_SHA}"
+          if [ -n "${{ steps.bump_pr.outputs.pull-request-url }}" ]; then
+            echo "Created/updated bump PR: ${{ steps.bump_pr.outputs.pull-request-url }}"
+          else
+            echo "No version changes detected; no bump PR created."
+          fi
 
       - name: Resolve release target SHA for force mode
         if: steps.pr_meta.outputs.bump == 'force'
@@ -126,10 +154,10 @@ jobs:
           echo "Release target SHA: ${MERGE_SHA}"
 
       - name: Derive release tag from pyproject version
-        if: steps.pr_meta.outputs.bump != 'none'
+        if: steps.pr_meta.outputs.bump == 'force'
         id: version_meta
         env:
-          TARGET_SHA: ${{ steps.release_target_auto.outputs.sha || steps.release_target_force.outputs.sha }}
+          TARGET_SHA: ${{ steps.release_target_force.outputs.sha }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -191,11 +219,11 @@ jobs:
             core.info(`Release tag will be ${tag}`);
 
       - name: Create GitHub release with generated notes
-        if: steps.pr_meta.outputs.bump != 'none'
+        if: steps.pr_meta.outputs.bump == 'force'
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.version_meta.outputs.tag }}
-          TARGET_SHA: ${{ steps.release_target_auto.outputs.sha || steps.release_target_force.outputs.sha }}
+          TARGET_SHA: ${{ steps.release_target_force.outputs.sha }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -107,7 +107,7 @@ jobs:
         id: bump_pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.RELEASE_APPROVER_TOKEN != '' && secrets.RELEASE_APPROVER_TOKEN || github.token }}
+          token: ${{ github.token }}
           base: main
           branch: ci/version-bump-main
           delete-branch: true
@@ -141,7 +141,7 @@ jobs:
       - name: Enable auto-merge for bump PR
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump) && steps.bump_pr.outputs.pull-request-number != ''
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_APPROVER_TOKEN != '' && secrets.RELEASE_APPROVER_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.bump_pr.outputs.pull-request-number }}
         run: |
           set -euo pipefail

--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -102,6 +102,17 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Bumped version: ${VERSION}"
 
+      - name: Require VERSION_BUMP_TOKEN
+        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
+        env:
+          VERSION_BUMP_TOKEN: ${{ secrets.VERSION_BUMP_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VERSION_BUMP_TOKEN:-}" ]; then
+            echo "::error title=Missing VERSION_BUMP_TOKEN::Set repository secret VERSION_BUMP_TOKEN to a fine-grained PAT from your PR-creator bot account (Contents: Read and write, Pull requests: Read and write)."
+            exit 1
+          fi
+
       - name: Create or update force release PR
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
         id: bump_pr
@@ -109,7 +120,7 @@ jobs:
         # refs/tags/v8.1.1 -> 5f6978faf089d4d20b00c7766989d076bb2fc7f1
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.VERSION_BUMP_TOKEN }}
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           base: main

--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -105,9 +105,13 @@ jobs:
       - name: Create or update force release PR
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
         id: bump_pr
-        uses: peter-evans/create-pull-request@v7
+        # v8.1.1 (2026-04-10)
+        # refs/tags/v8.1.1 -> 5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
           token: ${{ github.token }}
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           base: main
           branch: ci/version-bump-main
           delete-branch: true

--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -107,7 +107,7 @@ jobs:
         id: bump_pr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.RELEASE_APPROVER_TOKEN != '' && secrets.RELEASE_APPROVER_TOKEN || github.token }}
           base: main
           branch: ci/version-bump-main
           delete-branch: true
@@ -141,7 +141,7 @@ jobs:
       - name: Enable auto-merge for bump PR
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump) && steps.bump_pr.outputs.pull-request-number != ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_APPROVER_TOKEN != '' && secrets.RELEASE_APPROVER_TOKEN || github.token }}
           PR_NUMBER: ${{ steps.bump_pr.outputs.pull-request-number }}
         run: |
           set -euo pipefail

--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -125,6 +125,19 @@ jobs:
 
             This PR intentionally uses `[Force]` so manual version-file changes are allowed by repository checks.
 
+      - name: Auto-approve bump PR
+        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump) && steps.bump_pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_APPROVER_TOKEN }}
+          PR_NUMBER: ${{ steps.bump_pr.outputs.pull-request-number }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "RELEASE_APPROVER_TOKEN is not set. Skipping auto-approval."
+            exit 0
+          fi
+          gh pr review "$PR_NUMBER" --approve || echo "Auto-approval could not be applied."
+
       - name: Enable auto-merge for bump PR
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump) && steps.bump_pr.outputs.pull-request-number != ''
         env:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -115,6 +115,10 @@ jobs:
               return parsed.version;
             }
 
+            function escapeRegex(text) {
+              return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            }
+
             const files = [
               { path: "pyproject.toml", parser: getPyprojectVersion },
               { path: "viewer/package.json", parser: getPackageVersion },
@@ -275,8 +279,25 @@ jobs:
               if (typeof parsed.version !== "string") {
                 throw new Error(`Missing string \"version\" in ${path}`);
               }
-              parsed.version = "__VERSION__";
-              return JSON.stringify(parsed);
+              const escapedVersion = escapeRegex(parsed.version);
+              const pattern = new RegExp(
+                `(^|\\r?\\n)(\\s*"version"\\s*:\\s*)"${escapedVersion}"(\\s*,?)`,
+                "m",
+              );
+              let replaced = false;
+              const normalized = text.replace(
+                pattern,
+                (_match, linePrefix, keyPrefix, suffix) => {
+                  replaced = true;
+                  return `${linePrefix}${keyPrefix}"__VERSION__"${suffix}`;
+                },
+              );
+
+              if (!replaced) {
+                throw new Error(`Could not normalize \"version\" in ${path}`);
+              }
+
+              return normalized;
             }
 
             const files = [
@@ -433,10 +454,14 @@ jobs:
             const pr = context.payload.pull_request;
             const allowedApprover = "noodle-bucket-bot";
             const isForce = pr.title.startsWith("[Force]");
+            const allowedForceCreators = new Set(["github-actions[bot]", "noodle-byte-bot"]);
+            const isSameRepoHead =
+              pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
             const isActionGeneratedForce =
               isForce &&
               pr.head.ref === "ci/version-bump-main" &&
-              pr.user.login === "github-actions[bot]";
+              isSameRepoHead &&
+              allowedForceCreators.has(pr.user.login);
 
             const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner: context.repo.owner,

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -8,6 +8,7 @@ on:
     branches: [main]
     types: [opened, edited, synchronize, reopened, ready_for_review]
   pull_request_review:
+    branches: [main]
     types: [submitted, edited, dismissed]
 
 permissions:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches: [main]
     types: [opened, edited, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
 
 permissions:
   contents: read
@@ -173,7 +175,7 @@ jobs:
               core.info("No manual version changes detected in tracked version files.");
             }
 
-      - name: Force mode requires manual version change
+      - name: Force mode requires version-only changes in tracked files
         if: ${{ startsWith(github.event.pull_request.title, '[Force]') }}
         uses: actions/github-script@v7
         with:
@@ -234,15 +236,97 @@ jobs:
               return parsed.version;
             }
 
+            function normalizePyprojectVersion(text) {
+              const lines = text.split(/\r?\n/);
+              let inProjectSection = false;
+              let replaced = false;
+              const normalized = [];
+
+              for (const line of lines) {
+                const section = line.match(/^\s*\[([^\]]+)\]\s*$/);
+                if (section) {
+                  inProjectSection = section[1] === "project";
+                  normalized.push(line);
+                  continue;
+                }
+
+                if (inProjectSection) {
+                  const versionMatch = line.match(/^(\s*version\s*=\s*)"([^"]+)"(\s*)$/);
+                  if (versionMatch) {
+                    normalized.push(`${versionMatch[1]}"__VERSION__"${versionMatch[3]}`);
+                    replaced = true;
+                    continue;
+                  }
+                }
+
+                normalized.push(line);
+              }
+
+              if (!replaced) {
+                throw new Error("Could not normalize [project].version in pyproject.toml");
+              }
+
+              return normalized.join("\n");
+            }
+
+            function normalizePackageVersion(text, path) {
+              const parsed = JSON.parse(text);
+              if (typeof parsed.version !== "string") {
+                throw new Error(`Missing string \"version\" in ${path}`);
+              }
+              parsed.version = "__VERSION__";
+              return JSON.stringify(parsed);
+            }
+
             const files = [
-              { path: "pyproject.toml", parser: getPyprojectVersion },
-              { path: "viewer/package.json", parser: getPackageVersion },
-              { path: "electron/package.json", parser: getPackageVersion },
+              { path: "pyproject.toml", parser: getPyprojectVersion, normalizer: normalizePyprojectVersion },
+              { path: "viewer/package.json", parser: getPackageVersion, normalizer: normalizePackageVersion },
+              { path: "electron/package.json", parser: getPackageVersion, normalizer: normalizePackageVersion },
             ];
+            const allowedPaths = new Set(files.map((file) => file.path));
+            const changedFiles = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const changedPaths = changedFiles.map((file) => file.filename);
+            const disallowedPaths = changedPaths.filter((path) => !allowedPaths.has(path));
+            if (disallowedPaths.length > 0) {
+              core.setFailed(
+                [
+                  "[Force] PRs may only modify tracked version files.",
+                  "",
+                  "Allowed files:",
+                  ...files.map((file) => `- ${file.path}`),
+                  "",
+                  "Disallowed changed files:",
+                  ...disallowedPaths.map((path) => `- ${path}`),
+                ].join("\n"),
+              );
+              return;
+            }
+
+            const missingChangedPaths = files
+              .map((file) => file.path)
+              .filter((path) => !changedPaths.includes(path));
+            if (missingChangedPaths.length > 0) {
+              core.setFailed(
+                [
+                  "[Force] PRs must update version values in all tracked version files.",
+                  "",
+                  "Files missing from this PR diff:",
+                  ...missingChangedPaths.map((path) => `- ${path}`),
+                ].join("\n"),
+              );
+              return;
+            }
 
             const headVersions = {};
             const changedVersions = [];
+            const changedVersionPaths = new Set();
             const missingRequiredFiles = [];
+            const nonVersionEdits = [];
 
             for (const file of files) {
               const baseText = await readTextFile(baseOwner, baseRepo, file.path, baseRef);
@@ -258,8 +342,15 @@ jobs:
               const headVersion = file.parser(headText, file.path);
               headVersions[file.path] = headVersion;
 
+              const baseNormalized = file.normalizer(baseText, file.path);
+              const headNormalized = file.normalizer(headText, file.path);
+              if (baseNormalized !== headNormalized) {
+                nonVersionEdits.push(file.path);
+              }
+
               if (baseVersion !== headVersion) {
                 changedVersions.push(`${file.path}: ${baseVersion} -> ${headVersion}`);
+                changedVersionPaths.add(file.path);
               }
             }
 
@@ -279,16 +370,37 @@ jobs:
               return;
             }
 
-            if (changedVersions.length === 0) {
+            if (nonVersionEdits.length > 0) {
               core.setFailed(
                 [
-                  "[Force] requires a manual version change compared to main.",
-                  "No tracked version values changed in this PR.",
+                  "[Force] PRs may only change version fields.",
+                  "Detected non-version edits in tracked version files.",
+                  "",
+                  "Files with non-version edits:",
+                  ...nonVersionEdits.map((path) => `- ${path}`),
                   "",
                   "What to do:",
-                  "1. Update version fields in pyproject.toml, viewer/package.json, and electron/package.json.",
-                  "2. Keep those version values aligned to the same X.Y.Z.",
-                  "3. Keep the PR title prefix as [Force] for manual release mode.",
+                  "1. Revert any edits other than the version value.",
+                  "2. Keep only version updates in pyproject.toml, viewer/package.json, and electron/package.json.",
+                ].join("\n"),
+              );
+              return;
+            }
+
+            const unchangedVersionFiles = files
+              .map((file) => file.path)
+              .filter((path) => !changedVersionPaths.has(path));
+            if (unchangedVersionFiles.length > 0) {
+              core.setFailed(
+                [
+                  "[Force] requires a version bump in all tracked version files.",
+                  "",
+                  "Files where version did not change:",
+                  ...unchangedVersionFiles.map((path) => `- ${path}`),
+                  "",
+                  "What to do:",
+                  "1. Update version in pyproject.toml, viewer/package.json, and electron/package.json.",
+                  "2. Keep all three version values aligned to the same X.Y.Z.",
                 ].join("\n"),
               );
               return;
@@ -311,4 +423,83 @@ jobs:
               return;
             }
 
-            core.info("[Force] manual version change detected and version files are synchronized.");
+            core.info("[Force] version-only changes validated and version files are synchronized.");
+
+      - name: Restrict bot approvals to action-generated force PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const allowedApprover = "noodle-bucket-bot";
+            const isForce = pr.title.startsWith("[Force]");
+            const isActionGeneratedForce =
+              isForce &&
+              pr.head.ref === "ci/version-bump-main" &&
+              pr.user.login === "github-actions[bot]";
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const latestStateByUser = new Map();
+            for (const review of reviews) {
+              latestStateByUser.set(review.user.login, review.state);
+            }
+
+            const approvedUsers = [...latestStateByUser.entries()]
+              .filter(([, state]) => state === "APPROVED")
+              .map(([login]) => login);
+            const botApproved = approvedUsers.includes(allowedApprover);
+
+            if (botApproved && !isActionGeneratedForce) {
+              core.setFailed(
+                [
+                  `${allowedApprover} may only approve action-generated [Force] PRs.`,
+                  "",
+                  "Detected an approval from this bot on a disallowed PR.",
+                  "What to do:",
+                  "1. Dismiss the bot approval review.",
+                  "2. Use a human reviewer for this PR.",
+                ].join("\n"),
+              );
+              return;
+            }
+
+            if (isActionGeneratedForce) {
+              const unauthorizedApprovers = approvedUsers.filter(
+                (login) => login !== allowedApprover,
+              );
+              if (unauthorizedApprovers.length > 0) {
+                core.setFailed(
+                  [
+                    "Action-generated [Force] PRs may only be approved by noodle-bucket-bot.",
+                    "",
+                    "Unauthorized approving reviewers:",
+                    ...unauthorizedApprovers.map((login) => `- ${login}`),
+                    "",
+                    "What to do:",
+                    "1. Dismiss non-bot approvals on this PR.",
+                    "2. Keep only noodle-bucket-bot approval.",
+                  ].join("\n"),
+                );
+                return;
+              }
+
+              if (!botApproved) {
+                core.setFailed(
+                  [
+                    "Action-generated [Force] PR is waiting for noodle-bucket-bot approval.",
+                    "This check will pass automatically once the bot review is submitted.",
+                  ].join("\n"),
+                );
+                return;
+              }
+
+              core.info("Action-generated [Force] PR approval policy satisfied.");
+              return;
+            }
+
+            core.info("Bot approval policy satisfied for this PR.");

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -119,6 +119,10 @@ jobs:
               return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
             }
 
+            function escapeRegex(text) {
+              return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            }
+
             const files = [
               { path: "pyproject.toml", parser: getPyprojectVersion },
               { path: "viewer/package.json", parser: getPackageVersion },


### PR DESCRIPTION
## Summary
- fix `escapeRegex is not defined` runtime error in `PR Title Check`
- keep force-version validation logic intact by defining helper in the same github-script step

## Why
`[Force]` release PRs currently fail `enforce-title-prefix` due to helper scope mismatch, blocking the release flow.

## Validation
- `check yaml` pre-commit hook passed
- local YAML parse succeeded for `.github/workflows/pr-title-check.yml`
