### PR TITLE
[Patch] fix force PR title check runtime error

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -119,6 +119,10 @@ jobs:
               return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
             }
 
+            function escapeRegex(text) {
+              return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            }
+
             const files = [
               { path: "pyproject.toml", parser: getPyprojectVersion },
               { path: "viewer/package.json", parser: getPackageVersion },


### PR DESCRIPTION
## Summary
- fix `escapeRegex is not defined` runtime error in `PR Title Check`
- keep force-version validation logic intact by defining helper in the same github-script step

## Why
`[Force]` release PRs currently fail `enforce-title-prefix` due to helper scope mismatch, blocking the release flow.

## Validation
- `check yaml` pre-commit hook passed
- local YAML parse succeeded for `.github/workflows/pr-title-check.yml`
