### PR TITLE
[Patch] merge generated force PRs directly in one-bot mode

### DIFF
--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -140,14 +140,38 @@ jobs:
 
             This PR intentionally uses `[Force]` so manual version-file changes are allowed by repository checks.
 
-      - name: Enable auto-merge for bump PR
+      - name: Merge bump PR when checks are ready
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump) && steps.bump_pr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ secrets.VERSION_BUMP_TOKEN }}
           PR_NUMBER: ${{ steps.bump_pr.outputs.pull-request-number }}
         run: |
           set -euo pipefail
-          gh pr merge "$PR_NUMBER" --auto --squash || echo "Auto-merge could not be enabled automatically. Ensure noodle-bucket-bot can bypass required pull request approvals for main."
+          max_attempts=80
+          sleep_seconds=15
+          attempt=0
+
+          while [ "$attempt" -lt "$max_attempts" ]; do
+            attempt=$((attempt + 1))
+            echo "Attempt ${attempt}/${max_attempts}: merging bump PR #${PR_NUMBER}"
+
+            pr_state="$(gh pr view "$PR_NUMBER" --json state --jq .state)"
+            if [ "$pr_state" != "OPEN" ]; then
+              echo "PR #${PR_NUMBER} is already ${pr_state}. Nothing to merge."
+              exit 0
+            fi
+
+            if gh pr merge "$PR_NUMBER" --squash --delete-branch; then
+              echo "Merged bump PR #${PR_NUMBER}."
+              exit 0
+            fi
+
+            echo "PR #${PR_NUMBER} is not mergeable yet. Waiting ${sleep_seconds}s..."
+            sleep "$sleep_seconds"
+          done
+
+          echo "::error title=Timed out merging bump PR::PR #${PR_NUMBER} did not become mergeable within $((max_attempts * sleep_seconds / 60)) minutes."
+          exit 1
 
       - name: Report bump PR
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)


### PR DESCRIPTION
## Summary
- replace auto-merge enablement with direct merge retries in one-bot mode
- use `VERSION_BUMP_TOKEN` to attempt squash-merge until required checks are ready

## Why
`--auto` still waits for required reviews, so generated `[Force]` PRs remained blocked as `REVIEW_REQUIRED` in one-bot mode.

## Validation
- `check yaml` pre-commit hook passed
- local YAML parse succeeded for `.github/workflows/bump-version-on-merge.yml`
