### PR TITLE
[Patch] fix generated force PR checks not running

### DIFF
--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -135,15 +135,15 @@ jobs:
             exit 1
           fi
 
-          if [ "$existing_author" = "github-actions[bot]" ]; then
-            echo "Existing bump PR #${existing_number} already authored by github-actions[bot]."
+          if [ "$existing_author" = "noodle-bucket-bot" ]; then
+            echo "Existing bump PR #${existing_number} already authored by noodle-bucket-bot."
             exit 0
           fi
 
-          echo "Closing legacy bump PR #${existing_number} authored by ${existing_author} so it can be recreated by github-actions[bot]."
+          echo "Closing incompatible bump PR #${existing_number} authored by ${existing_author} so it can be recreated by noodle-bucket-bot."
           gh pr close "$existing_number" \
             --delete-branch \
-            --comment "Resetting this PR so it is recreated by github-actions[bot] for automated required-review approval flow."
+            --comment "Resetting this PR so it is recreated by noodle-bucket-bot for automated required-review approval flow."
 
       - name: Create or update force release PR
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
@@ -152,8 +152,8 @@ jobs:
         # refs/tags/v8.1.1 -> 5f6978faf089d4d20b00c7766989d076bb2fc7f1
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
         with:
-          # Keep PR author as github-actions[bot] so noodle-bucket-bot can approve it.
-          token: ${{ github.token }}
+          # Use VERSION_BUMP_TOKEN so pull_request workflows run on the generated PR.
+          token: ${{ secrets.VERSION_BUMP_TOKEN }}
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           base: main
@@ -173,10 +173,10 @@ jobs:
 
             This PR intentionally uses `[Force]` so manual version-file changes are allowed by repository checks.
 
-      - name: Approve bump PR as noodle-bucket-bot
+      - name: Approve bump PR as GitHub Actions
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump) && steps.bump_pr.outputs.pull-request-number != ''
         env:
-          GH_TOKEN: ${{ secrets.VERSION_BUMP_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.bump_pr.outputs.pull-request-number }}
         run: |
           set -euo pipefail
@@ -191,8 +191,8 @@ jobs:
           author_login="$(gh pr view "$PR_NUMBER" --json author --jq .author.login)"
 
           if [ "$reviewer_login" = "$author_login" ]; then
-            echo "::error title=Invalid bot approval setup::VERSION_BUMP_TOKEN resolves to ${reviewer_login}, which is also the PR author. Required-review rules disallow self-approval."
-            echo "Set VERSION_BUMP_TOKEN to noodle-bucket-bot and keep PR creation on GITHUB_TOKEN."
+            echo "::error title=Invalid approval actor setup::Approval actor ${reviewer_login} matches PR author ${author_login}. Required-review rules disallow self-approval."
+            echo "Use VERSION_BUMP_TOKEN for PR creation and GITHUB_TOKEN for approval."
             exit 1
           fi
 
@@ -204,7 +204,7 @@ jobs:
 
           gh pr review "$PR_NUMBER" \
             --approve \
-            --body "Automated approval for action-generated [Force] version bump PR."
+            --body "Automated approval from GitHub Actions for generated [Force] version bump PR."
           echo "Approved bump PR #${PR_NUMBER} as ${reviewer_login}."
 
       - name: Merge bump PR when checks are ready

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -447,13 +447,14 @@ jobs:
 
             core.info("[Force] version-only changes validated and version files are synchronized.");
 
-      - name: Enforce one-bot policy for action-generated force PRs
+      - name: Enforce automation policy for action-generated force PRs
         uses: actions/github-script@v7
         with:
           script: |
             const pr = context.payload.pull_request;
-            const forceApproverLogin = "noodle-bucket-bot";
-            const expectedActionAuthor = "github-actions[bot]";
+            const allowedForceApproverLogins = new Set(["app/github-actions", "github-actions[bot]"]);
+            const forceApproverDisplay = "GitHub Actions";
+            const expectedActionAuthor = "noodle-bucket-bot";
             const isForce = pr.title.startsWith("[Force]");
             const isSameRepoHead =
               pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
@@ -477,12 +478,12 @@ jobs:
             const approvedUsers = [...latestStateByUser.entries()]
               .filter(([, state]) => state === "APPROVED")
               .map(([login]) => login);
-            const botApproved = approvedUsers.includes(forceApproverLogin);
+            const botApproved = approvedUsers.some((login) => allowedForceApproverLogins.has(login));
 
             if (botApproved && !isActionGeneratedForce) {
               core.setFailed(
                 [
-                  `${forceApproverLogin} may only approve action-generated [Force] PRs.`,
+                  `${forceApproverDisplay} may only approve action-generated [Force] PRs.`,
                   "",
                   "Detected an approval from this bot on a disallowed PR.",
                   "What to do:",
@@ -501,7 +502,7 @@ jobs:
                     "",
                     `Detected PR author: ${pr.user.login}`,
                     "What to do:",
-                    "1. Ensure create-pull-request uses GITHUB_TOKEN.",
+                    "1. Ensure create-pull-request uses VERSION_BUMP_TOKEN from noodle-bucket-bot.",
                     "2. Re-run the bump workflow to recreate the PR with the correct author.",
                   ].join("\n"),
                 );
@@ -511,18 +512,19 @@ jobs:
               if (!botApproved) {
                 core.setFailed(
                   [
-                    `Action-generated [Force] PR requires an approval from ${forceApproverLogin}.`,
+                    `Action-generated [Force] PR requires an approval from ${forceApproverDisplay}.`,
                     "",
                     "What to do:",
-                    "1. Ensure VERSION_BUMP_TOKEN is set to noodle-bucket-bot.",
-                    "2. Re-run the bump workflow so it submits approval automatically.",
+                    "1. Ensure repository setting 'Allow GitHub Actions to create and approve pull requests' is enabled.",
+                    "2. Ensure workflow permissions allow pull-requests: write for GITHUB_TOKEN.",
+                    "3. Re-run the bump workflow so GitHub Actions submits approval automatically.",
                   ].join("\n"),
                 );
                 return;
               }
 
-              core.info("One-bot policy satisfied for action-generated [Force] PR.");
+              core.info("Automation policy satisfied for action-generated [Force] PR.");
               return;
             }
 
-            core.info("One-bot policy satisfied for this PR.");
+            core.info("Automation policy satisfied for this PR.");


### PR DESCRIPTION
## Root cause
Generated [Force] PR #127 was created with GITHUB_TOKEN (author `app/github-actions`).
PR events created by GITHUB_TOKEN do not trigger this repo's `pull_request` test workflows,
so required checks `test (3.11)` and `test (3.12)` never appeared. The merge loop then timed out.

## Fix
- create/update generated force PR with VERSION_BUMP_TOKEN (noodle-bucket-bot), so normal `pull_request` checks run
- auto-approve generated force PR with GITHUB_TOKEN (GitHub Actions), so approval actor differs from PR author
- align PR Title Check policy with this actor model
- close incompatible existing `ci/version-bump-main` PRs authored by the wrong actor so they are recreated correctly

## Expected behavior after merge
1. `[Patch]`/`[Minor]`/`[Major]` PR merges to `main`
2. bump workflow creates/updates `[Force]` PR as noodle-bucket-bot
3. required pull_request checks run (`test (3.11)`, `test (3.12)`, `CodeQL`, title check)
4. GitHub Actions auto-approves
5. merge loop merges as soon as branch policy requirements are satisfied
