### PR TITLE
[Patch] merge generated force PRs with bypass token

### DIFF
--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -173,26 +173,37 @@ jobs:
 
             This PR intentionally uses `[Force]` so manual version-file changes are allowed by repository checks.
 
-      - name: Merge or enable auto-merge for bump PR
+      - name: Merge bump PR with bypass actor when checks are ready
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump) && steps.bump_pr.outputs.pull-request-number != ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.VERSION_BUMP_TOKEN }}
           PR_NUMBER: ${{ steps.bump_pr.outputs.pull-request-number }}
         run: |
           set -euo pipefail
+          max_attempts=80
+          sleep_seconds=15
+          attempt=0
 
-          pr_state="$(gh pr view "$PR_NUMBER" --json state --jq .state)"
-          if [ "$pr_state" != "OPEN" ]; then
-            echo "PR #${PR_NUMBER} is already ${pr_state}. Nothing to merge."
-            exit 0
-          fi
+          while [ "$attempt" -lt "$max_attempts" ]; do
+            attempt=$((attempt + 1))
+            echo "Attempt ${attempt}/${max_attempts}: merging bump PR #${PR_NUMBER}"
 
-          if gh pr merge "$PR_NUMBER" --auto --squash --delete-branch; then
-            echo "Merged or enabled auto-merge for bump PR #${PR_NUMBER}."
-            exit 0
-          fi
+            pr_state="$(gh pr view "$PR_NUMBER" --json state --jq .state)"
+            if [ "$pr_state" != "OPEN" ]; then
+              echo "PR #${PR_NUMBER} is already ${pr_state}. Nothing to merge."
+              exit 0
+            fi
 
-          echo "::error title=Unable to merge bump PR::Failed to merge or enable auto-merge for PR #${PR_NUMBER}. Check branch protection and repository Actions permissions."
+            if gh pr merge "$PR_NUMBER" --squash --delete-branch; then
+              echo "Merged bump PR #${PR_NUMBER}."
+              exit 0
+            fi
+
+            echo "PR #${PR_NUMBER} is not mergeable yet. Waiting ${sleep_seconds}s..."
+            sleep "$sleep_seconds"
+          done
+
+          echo "::error title=Timed out merging bump PR::PR #${PR_NUMBER} did not become mergeable within $((max_attempts * sleep_seconds / 60)) minutes."
           exit 1
 
       - name: Report bump PR


### PR DESCRIPTION
## Why another fix
Current flow (after #130) enables auto-merge as `github-actions`, but generated force PRs still sit on "Awaiting approval" despite all checks passing.

Your screenshot of PR #131 confirms this exact state.

## Root cause
GitHub Actions auto-merge path is not bypassing `required_approving_review_count` for these generated `[Force]` PRs.

## Fix
- merge generated force PRs using `VERSION_BUMP_TOKEN` directly
- keep looped retries while checks are still running
- remove dependency on auto-merge approval state

This uses the explicit bypass actor you already configured in branch protection (`noodle-bucket-bot`).
