### PR TITLE
[Patch] auto-land force release PRs via app approval and gate

### DIFF
--- a/.github/RELEASE_AUTOMATION.md
+++ b/.github/RELEASE_AUTOMATION.md
@@ -1,0 +1,212 @@
+<!--
+  ~ SPDX-License-Identifier: MIT
+  ~ Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+  -->
+
+# Release Automation — Operator Guide
+
+This document is for repository maintainers. It describes how the automated
+release pipeline works and, more importantly, how to recover when it fails.
+
+End-user / library documentation lives in [`docs/`](../docs/index.md); this
+file is not part of the published docs site.
+
+## Contents
+
+1. [How the pipeline works](#how-the-pipeline-works)
+2. [PR title prefixes](#pr-title-prefixes)
+3. [The `release-pipeline-gate` required check](#the-release-pipeline-gate-required-check)
+4. [Stay-blocked recovery policy](#stay-blocked-recovery-policy)
+5. [Recovery: clearing a stuck gate](#recovery-clearing-a-stuck-gate)
+6. [Reference](#reference)
+
+---
+
+## How the pipeline works
+
+1. A contributor opens a PR against `main` with a release-prefix title
+   (`[Patch]`, `[Minor]`, `[Major]`, `[None]`, or `[Force]`).
+2. `Release Pipeline Gate`
+   ([`.github/workflows/release-pipeline-gate.yml`](workflows/release-pipeline-gate.yml))
+   posts a `release-pipeline-gate` commit status on the PR head. This is a
+   required check on `main`.
+3. When a `[Patch]/[Minor]/[Major]` PR is merged, `Bump Version On Merge`
+   ([`.github/workflows/bump-version-on-merge.yml`](workflows/bump-version-on-merge.yml))
+   does the following in order:
+   - Flips every other open source PR's `release-pipeline-gate` status to
+     `pending` so they cannot merge while a release is in flight.
+   - Fails fast (defensive check) if a release PR (`ci/version-bump-main`) is
+     already open. This must not happen if the gate is configured correctly,
+     but the check exists to prevent silent version downgrades or lost
+     releases if it ever does.
+   - Bumps the version files, opens a `[Force]` release PR as
+     `noodle-bucket-bot`, and approves it via the `bucket-release-approver`
+     GitHub App.
+   - Polls `gh pr merge --squash` until the PR merges.
+   - Re-runs against the merged release PR to create the GitHub release tag.
+   - Resets every other open source PR's gate back to `success`.
+
+## PR title prefixes
+
+| Prefix    | Effect when merged                                                | Gate status posted        |
+|-----------|-------------------------------------------------------------------|---------------------------|
+| `[Patch]` | Triggers a patch bump and release                                 | `success` if pipeline free, else `pending` |
+| `[Minor]` | Triggers a minor bump and release                                 | `success` if pipeline free, else `pending` |
+| `[Major]` | Triggers a major bump and release                                 | `success` if pipeline free, else `pending` |
+| `[None]`  | No bump, no release                                               | always `success`          |
+| `[Force]` | Manual / automation-generated bump (the release PR itself)        | always `success`          |
+
+`[Force]` PRs do not gate themselves and are normally only created by the
+bump workflow. Manual `[Force]` PRs are allowed but should be rare.
+
+## The `release-pipeline-gate` required check
+
+This is a custom commit-status check (not a GitHub Actions check run). It
+ensures that only one release process is active at a time.
+
+- **`success`** — no release PR is currently open. Source PRs with this status
+  are free to merge.
+- **`pending`** — a release PR is in flight (or the bump workflow failed
+  partway and the stay-blocked policy is keeping things locked).
+
+The status is named exactly `release-pipeline-gate` and is posted on each
+PR's head SHA. It is configured as a required status check on `main` in
+branch protection.
+
+## Stay-blocked recovery policy
+
+If `Bump Version On Merge` fails between flipping gates to `pending` and the
+final "Set release pipeline gate to success on open source PRs" step, every
+source PR's gate is intentionally left `pending`.
+
+This is deliberate. The alternatives — clearing on failure, or running the
+clear step with `if: always()` — would let new source PRs merge during a
+broken release pipeline, risking lost releases or version downgrades.
+
+When the pipeline is broken, no new releases land until a human investigates.
+Your three options to recover are below.
+
+## Recovery: clearing a stuck gate
+
+### Option 1 — re-run the bump workflow (preferred)
+
+If the bump PR is still salvageable, fix the underlying cause and re-run the
+last `Bump Version On Merge` run. A successful run will hit the
+"Set release pipeline gate to success on open source PRs" step and clear
+every gate automatically.
+
+```bash
+gh run list --workflow="Bump Version On Merge" --limit 5
+gh run rerun <run-id>
+gh run rerun <run-id> --failed   # only re-run failed jobs
+```
+
+### Option 2 — manually clear one PR
+
+There is no "delete a status" API. You overwrite the `pending` status by
+posting a fresh `success` status with the same context name on the same SHA.
+
+```bash
+PR=123  # the source PR you want to unblock
+SHA="$(gh pr view "$PR" --json headRefOid --jq .headRefOid)"
+gh api -X POST "repos/Noodle-Bytes/bucket/statuses/${SHA}" \
+  -f state=success \
+  -f context=release-pipeline-gate \
+  -f description='Manually cleared.' \
+  -f target_url="https://github.com/Noodle-Bytes/bucket/actions"
+```
+
+The required check turns green within a few seconds.
+
+### Option 3 — manually clear every open source PR
+
+Use this after fixing the underlying problem when several source PRs are
+queued behind the failed release.
+
+```bash
+REPO=Noodle-Bytes/bucket
+gh pr list --repo "$REPO" --state open --base main \
+  --json number,title,headRefOid \
+  --jq '.[] | select(.title | test("^\\[(Patch|Minor|Major)\\]")) | "\(.number) \(.headRefOid)"' \
+| while read -r pr sha; do
+    echo "Clearing gate on PR #${pr} (${sha:0:7})"
+    gh api -X POST "repos/${REPO}/statuses/${sha}" \
+      -f state=success \
+      -f context=release-pipeline-gate \
+      -f description='Manually cleared after release pipeline recovery.' \
+      -f target_url="https://github.com/${REPO}/actions" >/dev/null
+  done
+```
+
+### Pre-clear checklist
+
+Before running Option 2 or 3, confirm no release PR is genuinely in flight.
+If there is one, clearing the gate would let a source PR merge into the race
+the gate exists to prevent.
+
+```bash
+gh pr list --repo Noodle-Bytes/bucket \
+  --state open --base main \
+  --json number,title,headRepositoryOwner,headRefName \
+  --jq '[.[] | select(.headRefName == "ci/version-bump-main"
+                   and .headRepositoryOwner.login == "Noodle-Bytes")]'
+```
+
+This must return `[]` before you clear.
+
+### Common mistakes
+
+- **Wrong context name.** The context must be exactly `release-pipeline-gate`
+  (lowercase, hyphens). A typo posts a *new* required check that is missing
+  → permanently red.
+- **Wrong SHA.** Must be the PR's current head commit. If you push a new
+  commit later, `Release Pipeline Gate` re-evaluates from scratch on the new
+  SHA, so a manually-cleared status only sticks until the next push to that
+  PR.
+- **Token scope.** Your normal `gh` PAT with `repo` scope works. The status
+  is posted as you, which appears in the PR's "Checks" timeline.
+
+## Reference
+
+### Workflows
+
+- [`bump-version-on-merge.yml`](workflows/bump-version-on-merge.yml) —
+  detects merged source PRs, opens / approves / merges the `[Force]` release
+  PR, manages the `release-pipeline-gate` status during a release.
+- [`release-pipeline-gate.yml`](workflows/release-pipeline-gate.yml) —
+  posts the initial `release-pipeline-gate` status on every release-prefixed
+  PR opened against `main`. Uses `pull_request_target` so it works for fork
+  PRs.
+- [`pr-title-check.yml`](workflows/pr-title-check.yml) — enforces title
+  prefixes and restricts which actors may author or approve `[Force]` PRs.
+
+### Identities
+
+- **`noodle-bucket-bot`** — service-account user. Authors the `[Force]`
+  release PRs and merges them. Authentication via the `VERSION_BUMP_TOKEN`
+  secret. By policy (enforced in `pr-title-check.yml`), this account may
+  only author `[Force]` PRs on `ci/version-bump-main`.
+- **`bucket-release-approver` (GitHub App)** — approves the `[Force]` release
+  PR so it satisfies the "1 approving review" branch protection rule.
+  Authentication via `RELEASE_APPROVER_APP_ID` and
+  `RELEASE_APPROVER_PRIVATE_KEY` secrets. By policy, this app may only
+  approve `[Force]` PRs authored by `noodle-bucket-bot`.
+
+### Required status checks on `main`
+
+- `release-pipeline-gate` (custom commit status, posted by the gate workflow)
+- `CodeQL`
+- `test (3.11)`
+- `test (3.12)`
+
+Plus 1 approving review and `strict: true` (branch must be up-to-date with
+`main` before merging).
+
+### Branch protection bypass
+
+Bypass for required pull request reviews is granted to:
+
+- `noodle-bucket-bot` (so it can merge its own `[Force]` release PRs without
+  a human approval, in conjunction with the App approval).
+- `github-actions[bot]` (legacy; the App approval flow does not require it
+  but it is left in place for safety).

--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -11,9 +11,19 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  statuses: write
 
+# Source-PR runs (patch/minor/major/none) and the release-tag run triggered by
+# the bump PR's own merge are handled in separate concurrency groups so a
+# release-tag run can never cancel a queued source-PR run, which would silently
+# skip a release for that source PR.
 concurrency:
-  group: version-bump-main
+  group: >-
+    version-bump-main-${{
+      (github.event.pull_request.head.ref == 'ci/version-bump-main' && startsWith(github.event.pull_request.title, '[Force]'))
+      && 'release'
+      || 'source'
+    }}
   cancel-in-progress: false
 
 jobs:
@@ -58,6 +68,90 @@ jobs:
       - name: Force mode notice
         if: steps.pr_meta.outputs.bump == 'force'
         run: echo "PR title starts with [Force]. Skipping auto-bump and using merged commit version for tag/release."
+
+      # Lock the release pipeline by flipping the gate to 'pending' on every
+      # other open source PR before doing any other work. This narrows the race
+      # window where another source PR could be merged with a stale 'success'
+      # gate while this workflow is still spinning up.
+      - name: Set release pipeline gate to pending on open source PRs
+        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
+        uses: actions/github-script@v7
+        env:
+          MERGED_PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const mergedPr = Number(process.env.MERGED_PR_NUMBER);
+            const validPrefixes = ["[Patch]", "[Minor]", "[Major]"];
+
+            const sourcePRs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              base: "main",
+              per_page: 100,
+            });
+
+            let updated = 0;
+            for (const pr of sourcePRs) {
+              if (pr.number === mergedPr) continue;
+              if (pr.head.ref === "ci/version-bump-main") continue;
+              if (!validPrefixes.some((p) => pr.title.startsWith(p))) continue;
+
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: pr.head.sha,
+                state: "pending",
+                context: "release-pipeline-gate",
+                description: `Wait for release PR for source PR #${mergedPr} to land`,
+                target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              });
+              core.info(`Set release-pipeline-gate=pending on PR #${pr.number} (${pr.title})`);
+              updated += 1;
+            }
+            core.info(`Updated ${updated} open source PR(s) to pending.`);
+
+      # Strict release-per-PR: bail loudly if a release PR is already open.
+      # The release-pipeline-gate required check on source PRs is supposed to
+      # block this from happening; if we get here, the gate failed. Aborting
+      # without overwriting the in-flight bump prevents a silent version
+      # downgrade or a lost release for either the in-flight or current PR.
+      # Per the chosen "stay-blocked" recovery policy: gates remain 'pending'
+      # so no further releases land until a human investigates and either
+      # re-runs this workflow or manually clears the gate.
+      - name: Defensive check - fail if a release PR is already open
+        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          existing="$(gh pr list --state open --base main --head ci/version-bump-main --json number,title,url,author --jq '.[0] // empty')"
+          if [ -z "$existing" ]; then
+            echo "No open release PR on ci/version-bump-main; safe to proceed."
+            exit 0
+          fi
+
+          existing_number="$(echo "$existing" | jq -r .number)"
+          existing_title="$(echo "$existing" | jq -r .title)"
+          existing_url="$(echo "$existing" | jq -r .url)"
+          existing_author="$(echo "$existing" | jq -r .author.login)"
+
+          {
+            echo "::error title=Release pipeline race detected::An open release PR (#${existing_number}) is in flight and the release-pipeline-gate required status check should have prevented this source PR from merging."
+            echo ""
+            echo "Existing release PR:"
+            echo "  number: ${existing_number}"
+            echo "  title:  ${existing_title}"
+            echo "  author: ${existing_author}"
+            echo "  url:    ${existing_url}"
+            echo ""
+            echo "What to do:"
+            echo "1. Investigate why the release-pipeline-gate let this source PR (#${{ github.event.pull_request.number }}) merge while the release PR was still open."
+            echo "2. Once the in-flight release PR has merged, manually create a [Force] PR for this source PR's bump (see scripts/bump_version.py) so the release for this PR is not lost."
+            echo "3. Restore source PR gates by re-running this workflow on a successful source PR merge, or by posting a 'success' commit status with context 'release-pipeline-gate' on each open source PR's head SHA."
+          } >&2
+          exit 1
 
       # For automatic patch/minor/major bumps, create or update a release PR
       # instead of pushing directly to main. This preserves branch protection
@@ -113,38 +207,6 @@ jobs:
             exit 1
           fi
 
-      - name: Reset legacy force bump PR author
-        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          existing_number="$(gh pr list --state open --base main --head ci/version-bump-main --json number --jq '.[0].number // ""')"
-          if [ -z "$existing_number" ]; then
-            echo "No existing open bump PR on ci/version-bump-main."
-            exit 0
-          fi
-
-          existing_author="$(gh pr view "$existing_number" --json author --jq .author.login)"
-          existing_title="$(gh pr view "$existing_number" --json title --jq .title)"
-
-          if [[ "$existing_title" != \[Force\]* ]]; then
-            echo "::error title=Unexpected PR on ci/version-bump-main::Open PR #${existing_number} does not use a [Force] title: '${existing_title}'."
-            echo "Resolve the conflicting PR on ci/version-bump-main and re-run this workflow."
-            exit 1
-          fi
-
-          if [ "$existing_author" = "noodle-bucket-bot" ]; then
-            echo "Existing bump PR #${existing_number} already authored by noodle-bucket-bot."
-            exit 0
-          fi
-
-          echo "Closing incompatible bump PR #${existing_number} authored by ${existing_author} so it can be recreated by noodle-bucket-bot."
-          gh pr close "$existing_number" \
-            --delete-branch \
-            --comment "Resetting this PR so it is recreated by noodle-bucket-bot for automated required-review approval flow."
-
       - name: Create or update force release PR
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
         id: bump_pr
@@ -171,22 +233,59 @@ jobs:
             Source PR:
             - #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}
 
-            This PR intentionally uses `[Force]` so manual version-file changes are allowed by repository checks.
+            This PR uses `[Force]` so manual version-file changes are allowed by repository checks.
 
-      - name: Merge bump PR with bypass actor when checks are ready
+      # Mint a short-lived (1 hour) installation token for the bucket-release-approver GitHub App.
+      # The App is the second identity required to satisfy branch protection's "1 approval"
+      # rule on the bot-authored bump PR (noodle-bucket-bot cannot approve its own PR).
+      - name: Mint approver app installation token
+        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump) && steps.bump_pr.outputs.pull-request-number != ''
+        id: approver_token
+        # actions/create-github-app-token v3.1.1 (2026-04-11)
+        # refs/tags/v3.1.1 -> 1b10c78c7865c340bc4f6099eb2f838309f1e8c3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
+        with:
+          app-id: ${{ secrets.APPROVER_APP_ID }}
+          private-key: ${{ secrets.APPROVER_APP_PRIVATE_KEY }}
+
+      - name: Approve bump PR via approver app
+        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump) && steps.bump_pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ steps.approver_token.outputs.token }}
+          PR_NUMBER: ${{ steps.bump_pr.outputs.pull-request-number }}
+          REPO: ${{ github.repository }}
+          APP_SLUG: ${{ steps.approver_token.outputs.app-slug }}
+        run: |
+          set -euo pipefail
+          reviewer_login="${APP_SLUG}[bot]"
+          existing="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            --jq "[.[] | select(.user.login == \"$reviewer_login\" and .state == \"APPROVED\")] | length")"
+          if [ "$existing" -gt 0 ]; then
+            echo "PR #${PR_NUMBER} already approved by $reviewer_login; skipping."
+            exit 0
+          fi
+          echo "Approving PR #${PR_NUMBER} as $reviewer_login..."
+          gh api -X POST "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            -f event=APPROVE \
+            -f body="Auto-approved by ${reviewer_login} for action-generated [Force] release PR."
+
+      # Merge as noodle-bucket-bot (NOT github.token), because GITHUB_TOKEN-driven merges
+      # do not trigger downstream pull_request_target events, which would skip the [Force]
+      # release/tag step in this same workflow.
+      - name: Merge bump PR once checks pass
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump) && steps.bump_pr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ secrets.VERSION_BUMP_TOKEN }}
           PR_NUMBER: ${{ steps.bump_pr.outputs.pull-request-number }}
         run: |
           set -euo pipefail
-          max_attempts=80
+          max_attempts=40
           sleep_seconds=15
           attempt=0
 
           while [ "$attempt" -lt "$max_attempts" ]; do
             attempt=$((attempt + 1))
-            echo "Attempt ${attempt}/${max_attempts}: merging bump PR #${PR_NUMBER}"
+            echo "Attempt ${attempt}/${max_attempts}: trying to merge bump PR #${PR_NUMBER}"
 
             pr_state="$(gh pr view "$PR_NUMBER" --json state --jq .state)"
             if [ "$pr_state" != "OPEN" ]; then
@@ -199,12 +298,52 @@ jobs:
               exit 0
             fi
 
-            echo "PR #${PR_NUMBER} is not mergeable yet. Waiting ${sleep_seconds}s..."
+            echo "PR #${PR_NUMBER} not mergeable yet. Waiting ${sleep_seconds}s..."
             sleep "$sleep_seconds"
           done
 
           echo "::error title=Timed out merging bump PR::PR #${PR_NUMBER} did not become mergeable within $((max_attempts * sleep_seconds / 60)) minutes."
           exit 1
+
+      # Only on successful merge above. If this workflow fails earlier, gates
+      # stay 'pending' on open source PRs so no further releases land until a
+      # human investigates (per the chosen "stay-blocked" recovery policy).
+      - name: Set release pipeline gate to success on open source PRs
+        if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
+        uses: actions/github-script@v7
+        env:
+          MERGED_PR_NUMBER: ${{ github.event.pull_request.number }}
+        with:
+          script: |
+            const mergedPr = Number(process.env.MERGED_PR_NUMBER);
+            const validPrefixes = ["[Patch]", "[Minor]", "[Major]"];
+
+            const sourcePRs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              base: "main",
+              per_page: 100,
+            });
+
+            let updated = 0;
+            for (const pr of sourcePRs) {
+              if (pr.number === mergedPr) continue;
+              if (pr.head.ref === "ci/version-bump-main") continue;
+              if (!validPrefixes.some((p) => pr.title.startsWith(p))) continue;
+
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: pr.head.sha,
+                state: "success",
+                context: "release-pipeline-gate",
+                description: "No active release PR; clear to merge",
+              });
+              core.info(`Set release-pipeline-gate=success on PR #${pr.number} (${pr.title})`);
+              updated += 1;
+            }
+            core.info(`Cleared release-pipeline-gate on ${updated} open source PR(s).`);
 
       - name: Report bump PR
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)

--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -123,12 +123,17 @@ jobs:
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
 
-          existing="$(gh pr list --state open --base main --head ci/version-bump-main --json number,title,url,author --jq '.[0] // empty')"
+          # Restrict the head match to the BASE repo to avoid false positives
+          # from a fork PR that happens to use the same branch name.
+          existing="$(gh pr list --state open --base main \
+            --json number,title,url,author,headRepositoryOwner,headRefName \
+            --jq "[.[] | select(.headRefName == \"ci/version-bump-main\" and .headRepositoryOwner.login == \"${REPO_OWNER}\")] | .[0] // empty")"
           if [ -z "$existing" ]; then
-            echo "No open release PR on ci/version-bump-main; safe to proceed."
+            echo "No open release PR on ${REPO_OWNER}:ci/version-bump-main; safe to proceed."
             exit 0
           fi
 
@@ -287,10 +292,19 @@ jobs:
             attempt=$((attempt + 1))
             echo "Attempt ${attempt}/${max_attempts}: trying to merge bump PR #${PR_NUMBER}"
 
-            pr_state="$(gh pr view "$PR_NUMBER" --json state --jq .state)"
+            pr_info="$(gh pr view "$PR_NUMBER" --json state,merged)"
+            pr_state="$(echo "$pr_info" | jq -r .state)"
+            pr_merged="$(echo "$pr_info" | jq -r .merged)"
             if [ "$pr_state" != "OPEN" ]; then
-              echo "PR #${PR_NUMBER} is already ${pr_state}. Nothing to merge."
-              exit 0
+              if [ "$pr_merged" = "true" ]; then
+                echo "PR #${PR_NUMBER} was merged externally. Continuing."
+                exit 0
+              fi
+              # Closed without merge: stay-blocked policy. Fail loudly so
+              # downstream gate-clearing step does not run, leaving open
+              # source PRs in 'pending' until a human investigates.
+              echo "::error title=Bump PR closed without merging::PR #${PR_NUMBER} is ${pr_state} but was not merged. Release pipeline gates will remain pending until manually cleared."
+              exit 1
             fi
 
             if gh pr merge "$PR_NUMBER" --squash --delete-branch; then

--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+#
+# Operator guide (release pipeline overview, stay-blocked recovery policy,
+# and how to manually clear a stuck release-pipeline-gate):
+#   .github/RELEASE_AUTOMATION.md
 
 name: Bump Version On Merge
 

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -453,7 +453,14 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const expectedActionAuthor = "noodle-bucket-bot";
-            const restrictedApproverLogin = "noodle-bucket-bot";
+            // Identities that are scoped to the release-automation flow only and must
+            // never appear as approvers on human-authored or non-bump PRs. If a token
+            // for one of these identities ever leaks, this gate ensures the blast
+            // radius is bounded to the bot-authored bump PR on ci/version-bump-main.
+            const restrictedApprovers = new Set([
+              "noodle-bucket-bot",
+              "bucket-release-approver[bot]",
+            ]);
             const isForce = pr.title.startsWith("[Force]");
             const isSameRepoHead =
               pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
@@ -477,16 +484,18 @@ jobs:
             const approvedUsers = [...latestStateByUser.entries()]
               .filter(([, state]) => state === "APPROVED")
               .map(([login]) => login);
-            const restrictedBotApproved = approvedUsers.includes(restrictedApproverLogin);
+            const disallowedRestrictedApprovers = approvedUsers.filter((login) =>
+              restrictedApprovers.has(login),
+            );
 
-            if (restrictedBotApproved && !isActionGeneratedForce) {
+            if (disallowedRestrictedApprovers.length > 0 && !isActionGeneratedForce) {
               core.setFailed(
                 [
-                  `${restrictedApproverLogin} may only approve action-generated [Force] PRs.`,
+                  `Restricted release-automation identities may only approve action-generated [Force] PRs.`,
                   "",
-                  "Detected an approval from this bot on a disallowed PR.",
+                  `Detected disallowed approval(s): ${disallowedRestrictedApprovers.join(", ")}`,
                   "What to do:",
-                  "1. Dismiss the bot approval review.",
+                  "1. Dismiss the bot approval review(s) on this PR.",
                   "2. Use a human reviewer for this PR.",
                 ].join("\n"),
               );
@@ -508,6 +517,31 @@ jobs:
                 return;
               }
               core.info("Automation policy satisfied for action-generated [Force] PR.");
+              return;
+            }
+
+            // Inverse guard: if noodle-bucket-bot is the author, the PR MUST be
+            // an action-generated [Force] release. This blocks a leaked
+            // VERSION_BUMP_TOKEN from being used to open arbitrary PRs that
+            // would otherwise look benign (e.g. a [Patch] PR opened by the bot).
+            if (pr.user.login === expectedActionAuthor) {
+              core.setFailed(
+                [
+                  `${expectedActionAuthor} may only author action-generated [Force] release PRs.`,
+                  "",
+                  `Detected PR title:    ${pr.title}`,
+                  `Detected PR head ref: ${pr.head.ref}`,
+                  `Detected PR head repo: ${pr.head.repo.full_name}`,
+                  "",
+                  "Required for an action-generated [Force] PR:",
+                  "- Title must start with '[Force]'",
+                  "- Head ref must be 'ci/version-bump-main'",
+                  "- Head and base must be the same repository",
+                  "",
+                  "If this PR was not created by the Bump Version On Merge workflow,",
+                  "rotate the VERSION_BUMP_TOKEN secret immediately and close this PR.",
+                ].join("\n"),
+              );
               return;
             }
 

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+#
+# Enforces release-prefix titles ([Patch]/[Minor]/[Major]/[None]/[Force])
+# and restricts which actors may author or approve action-generated [Force]
+# release PRs. See .github/RELEASE_AUTOMATION.md for the full release
+# pipeline overview.
 
 name: PR Title Check
 

--- a/.github/workflows/release-pipeline-gate.yml
+++ b/.github/workflows/release-pipeline-gate.yml
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+# Required status check named 'release-pipeline-gate' on every PR with a
+# recognized release-prefix title.
+#
+# Posts a commit status on the PR's head SHA reflecting whether the release
+# pipeline is currently free:
+#
+#   - [None]  : always 'success' (does not bump or release).
+#   - [Force] : always 'success' (it IS the release, does not gate itself).
+#   - [Patch]/[Minor]/[Major]: 'success' when no release PR
+#     (head=ci/version-bump-main) is open; 'pending' otherwise.
+#
+# The bump workflow (`Bump Version On Merge`) keeps this status fresh
+# dynamically: it flips every other open source PR's gate to 'pending' the
+# moment a source PR merges, and back to 'success' once the release PR has
+# successfully merged. If the bump workflow fails before reaching the
+# success step, gates intentionally stay 'pending' (stay-blocked policy)
+# until a human investigates.
+
+name: Release Pipeline Gate
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+# Avoid stomping on a fresher run for the same PR; always keep the latest.
+concurrency:
+  group: release-pipeline-gate-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  set-gate:
+    if: |
+      startsWith(github.event.pull_request.title, '[Patch]') ||
+      startsWith(github.event.pull_request.title, '[Minor]') ||
+      startsWith(github.event.pull_request.title, '[Major]') ||
+      startsWith(github.event.pull_request.title, '[None]') ||
+      startsWith(github.event.pull_request.title, '[Force]')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Set initial release pipeline gate status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const sha = pr.head.sha;
+            const isNone = pr.title.startsWith("[None]");
+            const isForce = pr.title.startsWith("[Force]");
+
+            // [None] PRs do not interact with the release pipeline.
+            if (isNone) {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: "success",
+                context: "release-pipeline-gate",
+                description: "[None] PR; no release impact, clear to merge",
+              });
+              core.info(`PR #${pr.number} is [None]; gate set to success.`);
+              return;
+            }
+
+            // The auto-generated [Force] release PR IS the in-flight release;
+            // it does not block itself. It must still satisfy the required
+            // gate status, so post 'success' on it directly.
+            if (isForce) {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: "success",
+                context: "release-pipeline-gate",
+                description: "Release PR; gate does not apply to itself",
+              });
+              core.info(`PR #${pr.number} is [Force]; gate set to success (does not gate itself).`);
+              return;
+            }
+
+            const existing = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              base: "main",
+              head: `${context.repo.owner}:ci/version-bump-main`,
+              per_page: 100,
+            });
+
+            const active = existing[0];
+            if (active) {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha,
+                state: "pending",
+                context: "release-pipeline-gate",
+                description: `Wait for release PR #${active.number} to land`,
+                target_url: active.html_url,
+              });
+              core.info(
+                `PR #${pr.number} gated pending: release PR #${active.number} (${active.title}) is in flight.`,
+              );
+              return;
+            }
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha,
+              state: "success",
+              context: "release-pipeline-gate",
+              description: "No active release PR; clear to merge",
+            });
+            core.info(`PR #${pr.number} gated success: no active release PR.`);

--- a/.github/workflows/release-pipeline-gate.yml
+++ b/.github/workflows/release-pipeline-gate.yml
@@ -21,8 +21,13 @@
 
 name: Release Pipeline Gate
 
+# Uses pull_request_target (NOT pull_request) so the workflow runs with the
+# base repo's GITHUB_TOKEN and can post commit statuses on PRs from forks.
+# This is safe because the only step is an actions/github-script call that
+# never checks out, builds, or executes any code from the head ref. It only
+# reads metadata (title, head SHA, head ref) and posts a commit status.
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [opened, reopened, synchronize, ready_for_review, edited]
 

--- a/.github/workflows/release-pipeline-gate.yml
+++ b/.github/workflows/release-pipeline-gate.yml
@@ -18,6 +18,9 @@
 # successfully merged. If the bump workflow fails before reaching the
 # success step, gates intentionally stay 'pending' (stay-blocked policy)
 # until a human investigates.
+#
+# Operator guide (including how to manually clear a stuck gate):
+#   .github/RELEASE_AUTOMATION.md
 
 name: Release Pipeline Gate
 


### PR DESCRIPTION
Solves the long-standing problem where action-generated [Force] release PRs sat waiting for human approval indefinitely.

What changes:

- New workflow .github/workflows/release-pipeline-gate.yml posts a release-pipeline-gate commit status on every PR with a recognized release-prefix title. [None] and [Force] PRs are always success; [Patch]/[Minor]/[Major] PRs are pending while a ci/version-bump-main release PR is open, success otherwise.

- Bump Version On Merge now (a) flips every other open source PR's release-pipeline-gate to pending the moment a source PR merges, before doing any other work, narrowing the race window; (b) bails loudly with a clear "release pipeline race detected" error if a release PR is somehow already open when the workflow starts, never silently overwriting an in-flight bump; (c) flips gates back to success only after the release PR has merged successfully (no always() cleanup), implementing a stay-blocked recovery policy where stuck releases require a human to investigate before more PRs land; (d) splits the concurrency group so the release-tag run triggered by the bump PR's own merge cannot cancel a queued source-PR run.

- Bump workflow uses a short-lived bucket-release-approver GitHub App installation token to programmatically approve the generated [Force] PR, satisfying branch protection's required-reviews rule without a long-lived PAT and without depending on bypass allowances.

- pr-title-check.yml restricts approvals: identities scoped to release automation (noodle-bucket-bot, bucket-release-approver[bot]) may only approve action-generated [Force] PRs on ci/version-bump-main. Adds an inverse author guard: if noodle-bucket-bot is the PR author, the PR must be an action-generated [Force] release; otherwise fail with rotate-token instructions, bounding blast radius if VERSION_BUMP_TOKEN ever leaks.

Required follow-up: add release-pipeline-gate to the required status checks on the main branch protection rule once this PR is merged (or sooner, after the gate workflow has posted its first status on this PR).