### PR TITLE
[Patch] fix release-create step failing pre-checkout in [Force] path

### DIFF
--- a/.github/RELEASE_AUTOMATION.md
+++ b/.github/RELEASE_AUTOMATION.md
@@ -25,7 +25,7 @@ file is not part of the published docs site.
 ## How the pipeline works
 
 1. A contributor opens a PR against `main` with a release-prefix title
-   (`[Patch]`, `[Minor]`, `[Major]`, `[None]`, or `[Force]`).
+   (`[Patch]`, `[Minor]`, `[Major]`, `[None]`, or `[Release]`).
 2. `Release Pipeline Gate`
    ([`.github/workflows/release-pipeline-gate.yml`](workflows/release-pipeline-gate.yml))
    posts a `release-pipeline-gate` commit status on the PR head. This is a
@@ -39,7 +39,7 @@ file is not part of the published docs site.
      already open. This must not happen if the gate is configured correctly,
      but the check exists to prevent silent version downgrades or lost
      releases if it ever does.
-   - Bumps the version files, opens a `[Force]` release PR as
+   - Bumps the version files, opens a `[Release]` PR as
      `noodle-bucket-bot`, and approves it via the `bucket-release-approver`
      GitHub App.
    - Polls `gh pr merge --squash` until the PR merges.
@@ -54,10 +54,10 @@ file is not part of the published docs site.
 | `[Minor]` | Triggers a minor bump and release                                 | `success` if pipeline free, else `pending` |
 | `[Major]` | Triggers a major bump and release                                 | `success` if pipeline free, else `pending` |
 | `[None]`  | No bump, no release                                               | always `success`          |
-| `[Force]` | Manual / automation-generated bump (the release PR itself)        | always `success`          |
+| `[Release]` | Auto-generated release PR, or manual release (the release PR itself) | always `success`      |
 
-`[Force]` PRs do not gate themselves and are normally only created by the
-bump workflow. Manual `[Force]` PRs are allowed but should be rare.
+`[Release]` PRs do not gate themselves and are normally only created by the
+bump workflow. Manual `[Release]` PRs are allowed but should be rare.
 
 ## The `release-pipeline-gate` required check
 
@@ -171,26 +171,26 @@ This must return `[]` before you clear.
 ### Workflows
 
 - [`bump-version-on-merge.yml`](workflows/bump-version-on-merge.yml) —
-  detects merged source PRs, opens / approves / merges the `[Force]` release
-  PR, manages the `release-pipeline-gate` status during a release.
+  detects merged source PRs, opens / approves / merges the `[Release]` PR,
+  manages the `release-pipeline-gate` status during a release.
 - [`release-pipeline-gate.yml`](workflows/release-pipeline-gate.yml) —
   posts the initial `release-pipeline-gate` status on every release-prefixed
   PR opened against `main`. Uses `pull_request_target` so it works for fork
   PRs.
 - [`pr-title-check.yml`](workflows/pr-title-check.yml) — enforces title
-  prefixes and restricts which actors may author or approve `[Force]` PRs.
+  prefixes and restricts which actors may author or approve `[Release]` PRs.
 
 ### Identities
 
-- **`noodle-bucket-bot`** — service-account user. Authors the `[Force]`
-  release PRs and merges them. Authentication via the `VERSION_BUMP_TOKEN`
+- **`noodle-bucket-bot`** — service-account user. Authors the `[Release]`
+  PRs and merges them. Authentication via the `VERSION_BUMP_TOKEN`
   secret. By policy (enforced in `pr-title-check.yml`), this account may
-  only author `[Force]` PRs on `ci/version-bump-main`.
-- **`bucket-release-approver` (GitHub App)** — approves the `[Force]` release
-  PR so it satisfies the "1 approving review" branch protection rule.
+  only author `[Release]` PRs on `ci/version-bump-main`.
+- **`bucket-release-approver` (GitHub App)** — approves the `[Release]` PR
+  so it satisfies the "1 approving review" branch protection rule.
   Authentication via `RELEASE_APPROVER_APP_ID` and
   `RELEASE_APPROVER_PRIVATE_KEY` secrets. By policy, this app may only
-  approve `[Force]` PRs authored by `noodle-bucket-bot`.
+  approve `[Release]` PRs authored by `noodle-bucket-bot`.
 
 ### Required status checks on `main`
 
@@ -206,7 +206,7 @@ Plus 1 approving review and `strict: true` (branch must be up-to-date with
 
 Bypass for required pull request reviews is granted to:
 
-- `noodle-bucket-bot` (so it can merge its own `[Force]` release PRs without
+- `noodle-bucket-bot` (so it can merge its own `[Release]` PRs without
   a human approval, in conjunction with the App approval).
 - `github-actions[bot]` (legacy; the App approval flow does not require it
   but it is left in place for safety).

--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -457,6 +457,9 @@ jobs:
         if: steps.pr_meta.outputs.bump == 'force'
         env:
           GH_TOKEN: ${{ github.token }}
+          # GH_REPO is required because the [Force] code path does not run
+          # actions/checkout, so `gh` has no local .git to detect the repo.
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.version_meta.outputs.tag }}
           TARGET_SHA: ${{ steps.release_target_force.outputs.sha }}
         run: |

--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -208,16 +208,33 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Bumped version: ${VERSION}"
 
-      - name: Require VERSION_BUMP_TOKEN
+      - name: Validate VERSION_BUMP_TOKEN
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
         env:
           VERSION_BUMP_TOKEN: ${{ secrets.VERSION_BUMP_TOKEN }}
         run: |
           set -euo pipefail
+          expected_login="noodle-bucket-bot"
+
           if [ -z "${VERSION_BUMP_TOKEN:-}" ]; then
-            echo "::error title=Missing VERSION_BUMP_TOKEN::Set repository secret VERSION_BUMP_TOKEN to a PAT from noodle-bucket-bot (repo scope for classic PAT, or fine-grained Contents: Read and write + Pull requests: Read and write)."
+            echo "::error title=Missing VERSION_BUMP_TOKEN::Set repository secret VERSION_BUMP_TOKEN to a PAT from ${expected_login} (repo scope for classic PAT, or fine-grained Contents: Read and write + Pull requests: Read and write)."
             exit 1
           fi
+
+          # Validate the token is not expired/revoked and belongs to the right account.
+          # An expired PAT is non-empty but would silently fail later steps.
+          if ! login="$(GH_TOKEN="${VERSION_BUMP_TOKEN}" gh api user --jq .login 2>&1)"; then
+            echo "::error title=Invalid VERSION_BUMP_TOKEN::Token authentication failed. It may be expired or revoked. Renew the PAT for ${expected_login} and update the VERSION_BUMP_TOKEN secret."
+            echo "gh api user output: ${login}"
+            exit 1
+          fi
+
+          if [ "$login" != "$expected_login" ]; then
+            echo "::error title=Wrong VERSION_BUMP_TOKEN owner::Token belongs to '${login}', expected '${expected_login}'. Update VERSION_BUMP_TOKEN to a PAT from ${expected_login}."
+            exit 1
+          fi
+
+          echo "VERSION_BUMP_TOKEN is valid (authenticated as ${login})."
 
       - name: Create or update release PR
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
@@ -317,13 +334,20 @@ jobs:
               exit 1
             fi
 
-            if gh pr merge "$PR_NUMBER" --squash --delete-branch; then
+            merge_output="$(gh pr merge "$PR_NUMBER" --squash --delete-branch 2>&1)" && {
               echo "Merged bump PR #${PR_NUMBER}."
               exit 0
-            fi
-
-            echo "PR #${PR_NUMBER} not mergeable yet. Waiting ${sleep_seconds}s..."
-            sleep "$sleep_seconds"
+            } || {
+              # Fail immediately on auth errors rather than retrying for 10 minutes
+              # with a misleading "not mergeable yet" message.
+              if echo "$merge_output" | grep -qiE "401|403|bad credentials|unauthorized|forbidden"; then
+                echo "::error title=Authentication failure merging bump PR::VERSION_BUMP_TOKEN authentication failed on gh pr merge. The token may have expired since the validation step. Renew it and update the VERSION_BUMP_TOKEN secret."
+                echo "gh pr merge output: ${merge_output}"
+                exit 1
+              fi
+              echo "PR #${PR_NUMBER} not mergeable yet (${merge_output}). Waiting ${sleep_seconds}s..."
+              sleep "$sleep_seconds"
+            }
           done
 
           echo "::error title=Timed out merging bump PR::PR #${PR_NUMBER} did not become mergeable within $((max_attempts * sleep_seconds / 60)) minutes."

--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -24,7 +24,7 @@ permissions:
 concurrency:
   group: >-
     version-bump-main-${{
-      (github.event.pull_request.head.ref == 'ci/version-bump-main' && startsWith(github.event.pull_request.title, '[Force]'))
+      (github.event.pull_request.head.ref == 'ci/version-bump-main' && startsWith(github.event.pull_request.title, '[Release]'))
       && 'release'
       || 'source'
     }}
@@ -55,12 +55,12 @@ jobs:
             \[None\]*)
               echo "bump=none" >> "$GITHUB_OUTPUT"
               ;;
-            \[Force\]*)
-              echo "bump=force" >> "$GITHUB_OUTPUT"
+            \[Release\]*)
+              echo "bump=release" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "Unsupported PR title prefix: '$PR_TITLE'"
-              echo "Expected one of: [Patch], [Minor], [Major], [None], [Force]"
+              echo "Expected one of: [Patch], [Minor], [Major], [None], [Release]"
               exit 1
               ;;
           esac
@@ -69,9 +69,9 @@ jobs:
         if: steps.pr_meta.outputs.bump == 'none'
         run: echo "PR title starts with [None]. Skipping version bump, tag, and release."
 
-      - name: Force mode notice
-        if: steps.pr_meta.outputs.bump == 'force'
-        run: echo "PR title starts with [Force]. Skipping auto-bump and using merged commit version for tag/release."
+      - name: Release mode notice
+        if: steps.pr_meta.outputs.bump == 'release'
+        run: echo "PR title starts with [Release]. Skipping auto-bump and using merged commit version for tag/release."
 
       # Lock the release pipeline by flipping the gate to 'pending' on every
       # other open source PR before doing any other work. This narrows the race
@@ -160,7 +160,7 @@ jobs:
             echo ""
             echo "What to do:"
             echo "1. Investigate why the release-pipeline-gate let this source PR (#${{ github.event.pull_request.number }}) merge while the release PR was still open."
-            echo "2. Once the in-flight release PR has merged, manually create a [Force] PR for this source PR's bump (see scripts/bump_version.py) so the release for this PR is not lost."
+            echo "2. Once the in-flight release PR has merged, manually create a [Release] PR for this source PR's bump (see scripts/bump_version.py) so the release for this PR is not lost."
             echo "3. Restore source PR gates by re-running this workflow on a successful source PR merge, or by posting a 'success' commit status with context 'release-pipeline-gate' on each open source PR's head SHA."
           } >&2
           exit 1
@@ -219,7 +219,7 @@ jobs:
             exit 1
           fi
 
-      - name: Create or update force release PR
+      - name: Create or update release PR
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
         id: bump_pr
         # v8.1.1 (2026-04-10)
@@ -238,14 +238,14 @@ jobs:
             electron/package.json
             viewer/package.json
           commit-message: "chore: bump version (${{ steps.pr_meta.outputs.bump }})"
-          title: "[Force] release v${{ steps.bumped_version.outputs.version }}"
+          title: "[Release] release v${{ steps.bumped_version.outputs.version }}"
           body: |
             Auto-generated version bump for a merged `${{ steps.pr_meta.outputs.bump }}` PR.
 
             Source PR:
             - #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}
 
-            This PR uses `[Force]` so manual version-file changes are allowed by repository checks.
+            This PR uses `[Release]` so manual version-file changes are allowed by repository checks.
 
       # Mint a short-lived (1 hour) installation token for the bucket-release-approver GitHub App.
       # The App is the second identity required to satisfy branch protection's "1 approval"
@@ -279,10 +279,10 @@ jobs:
           echo "Approving PR #${PR_NUMBER} as $reviewer_login..."
           gh api -X POST "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
             -f event=APPROVE \
-            -f body="Auto-approved by ${reviewer_login} for action-generated [Force] release PR."
+            -f body="Auto-approved by ${reviewer_login} for action-generated [Release] PR."
 
       # Merge as noodle-bucket-bot (NOT github.token), because GITHUB_TOKEN-driven merges
-      # do not trigger downstream pull_request_target events, which would skip the [Force]
+      # do not trigger downstream pull_request_target events, which would skip the [Release]
       # release/tag step in this same workflow.
       - name: Merge bump PR once checks pass
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump) && steps.bump_pr.outputs.pull-request-number != ''
@@ -378,8 +378,8 @@ jobs:
             echo "No version changes detected; no bump PR created."
           fi
 
-      - name: Resolve release target SHA for force mode
-        if: steps.pr_meta.outputs.bump == 'force'
+      - name: Resolve release target SHA for release mode
+        if: steps.pr_meta.outputs.bump == 'release'
         id: release_target_force
         env:
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
@@ -389,7 +389,7 @@ jobs:
           echo "Release target SHA: ${MERGE_SHA}"
 
       - name: Derive release tag from pyproject version
-        if: steps.pr_meta.outputs.bump == 'force'
+        if: steps.pr_meta.outputs.bump == 'release'
         id: version_meta
         env:
           TARGET_SHA: ${{ steps.release_target_force.outputs.sha }}
@@ -454,10 +454,10 @@ jobs:
             core.info(`Release tag will be ${tag}`);
 
       - name: Create GitHub release with generated notes
-        if: steps.pr_meta.outputs.bump == 'force'
+        if: steps.pr_meta.outputs.bump == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
-          # GH_REPO is required because the [Force] code path does not run
+          # GH_REPO is required because the [Release] code path does not run
           # actions/checkout, so `gh` has no local .git to detect the repo.
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.version_meta.outputs.tag }}

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,10 +1,9 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
 #
-# Enforces release-prefix titles ([Patch]/[Minor]/[Major]/[None]/[Force])
-# and restricts which actors may author or approve action-generated [Force]
-# release PRs. See .github/RELEASE_AUTOMATION.md for the full release
-# pipeline overview.
+# Enforces release-prefix titles ([Patch]/[Minor]/[Major]/[None]/[Release])
+# and restricts which actors may author or approve action-generated [Release]
+# PRs. See .github/RELEASE_AUTOMATION.md for the full release pipeline overview.
 
 name: PR Title Check
 
@@ -31,11 +30,11 @@ jobs:
           set -euo pipefail
 
           case "$PR_TITLE" in
-            \[Patch\]*|\[Minor\]*|\[Major\]*|\[None\]*|\[Force\]*)
+            \[Patch\]*|\[Minor\]*|\[Major\]*|\[None\]*|\[Release\]*)
               echo "PR title prefix is valid."
               ;;
             *)
-              echo "::error title=Invalid PR title prefix::PR title must start with one of: [Patch], [Minor], [Major], [None], [Force]"
+              echo "::error title=Invalid PR title prefix::PR title must start with one of: [Patch], [Minor], [Major], [None], [Release]"
               echo "Invalid PR title: '$PR_TITLE'"
               echo ""
               echo "How to fix:"
@@ -47,20 +46,20 @@ jobs:
               echo "[Minor] Backward-compatible feature/improvement (bump minor; create tag/release)."
               echo "[Major] Breaking change (bump major; create tag/release)."
               echo "[None] No release-impacting change (no version bump, no tag, no release)."
-              echo "[Force] Manual release mode (no auto bump; requires version change; allow version-file edits; create tag/release)."
+              echo "[Release] Manual release mode (no auto bump; requires version change; allow version-file edits; create tag/release)."
               echo ""
               echo "Examples:"
               echo "[Patch] fix crash when loading archive"
               echo "[Minor] add CSV import filters"
               echo "[Major] remove legacy JSON schema"
               echo "[None] docs cleanup for coverage guide"
-              echo "[Force] release v2.3.0 with manual version update"
+              echo "[Release] release v2.3.0 with manual version update"
               exit 1
               ;;
           esac
 
       - name: Block manual version changes in PRs
-        if: ${{ !startsWith(github.event.pull_request.title, '[Force]') }}
+        if: ${{ !startsWith(github.event.pull_request.title, '[Release]') }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -171,7 +170,7 @@ jobs:
                   "",
                   "What to do:",
                   "1. Revert version field edits in pyproject.toml, viewer/package.json, and electron/package.json.",
-                  "2. Keep your PR title prefix as [Patch]/[Minor]/[Major]/[None] for automated versioning, or use [Force] for manual versioning + release.",
+                  "2. Keep your PR title prefix as [Patch]/[Minor]/[Major]/[None] for automated versioning, or use [Release] for manual versioning + release.",
                   "",
                   "Detected manual version changes:",
                   ...changedVersions.map((line) => `- ${line}`),
@@ -181,8 +180,8 @@ jobs:
               core.info("No manual version changes detected in tracked version files.");
             }
 
-      - name: Force mode requires version-only changes in tracked files
-        if: ${{ startsWith(github.event.pull_request.title, '[Force]') }}
+      - name: Release mode requires version-only changes in tracked files
+        if: ${{ startsWith(github.event.pull_request.title, '[Release]') }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -322,7 +321,7 @@ jobs:
             if (disallowedPaths.length > 0) {
               core.setFailed(
                 [
-                  "[Force] PRs may only modify tracked version files.",
+                  "[Release] PRs may only modify tracked version files.",
                   "",
                   "Allowed files:",
                   ...files.map((file) => `- ${file.path}`),
@@ -340,7 +339,7 @@ jobs:
             if (missingChangedPaths.length > 0) {
               core.setFailed(
                 [
-                  "[Force] PRs must update version values in all tracked version files.",
+                  "[Release] PRs must update version values in all tracked version files.",
                   "",
                   "Files missing from this PR diff:",
                   ...missingChangedPaths.map((path) => `- ${path}`),
@@ -384,7 +383,7 @@ jobs:
             if (missingRequiredFiles.length > 0) {
               core.setFailed(
                 [
-                  "[Force] requires all version files to exist in both base and head refs.",
+                  "[Release] requires all version files to exist in both base and head refs.",
                   "",
                   "What to do:",
                   "1. Ensure pyproject.toml, viewer/package.json, and electron/package.json all exist.",
@@ -400,7 +399,7 @@ jobs:
             if (nonVersionEdits.length > 0) {
               core.setFailed(
                 [
-                  "[Force] PRs may only change version fields.",
+                  "[Release] PRs may only change version fields.",
                   "Detected non-version edits in tracked version files.",
                   "",
                   "Files with non-version edits:",
@@ -420,7 +419,7 @@ jobs:
             if (unchangedVersionFiles.length > 0) {
               core.setFailed(
                 [
-                  "[Force] requires a version bump in all tracked version files.",
+                  "[Release] requires a version bump in all tracked version files.",
                   "",
                   "Files where version did not change:",
                   ...unchangedVersionFiles.map((path) => `- ${path}`),
@@ -437,7 +436,7 @@ jobs:
             if (uniqueHeadVersions.length !== 1) {
               core.setFailed(
                 [
-                  "[Force] requires synchronized version values.",
+                  "[Release] requires synchronized version values.",
                   "Tracked version files do not all match after your changes.",
                   "",
                   "Current head versions:",
@@ -450,27 +449,28 @@ jobs:
               return;
             }
 
-            core.info("[Force] version-only changes validated and version files are synchronized.");
+            core.info("[Release] version-only changes validated and version files are synchronized.");
 
-      - name: Enforce automation policy for action-generated force PRs
+      - name: Enforce automation policy for action-generated release PRs
         uses: actions/github-script@v7
         with:
           script: |
             const pr = context.payload.pull_request;
             const expectedActionAuthor = "noodle-bucket-bot";
             // Identities that are scoped to the release-automation flow only and must
-            // never appear as approvers on human-authored or non-bump PRs. If a token
-            // for one of these identities ever leaks, this gate ensures the blast
-            // radius is bounded to the bot-authored bump PR on ci/version-bump-main.
+            // never appear as approvers on human-authored or non-release PRs. If a
+            // token for one of these identities ever leaks, this gate ensures the
+            // blast radius is bounded to the bot-authored release PR on
+            // ci/version-bump-main.
             const restrictedApprovers = new Set([
               "noodle-bucket-bot",
               "bucket-release-approver[bot]",
             ]);
-            const isForce = pr.title.startsWith("[Force]");
+            const isRelease = pr.title.startsWith("[Release]");
             const isSameRepoHead =
               pr.head.repo.full_name === `${context.repo.owner}/${context.repo.repo}`;
-            const isActionGeneratedForce =
-              isForce &&
+            const isActionGeneratedRelease =
+              isRelease &&
               pr.head.ref === "ci/version-bump-main" &&
               isSameRepoHead;
 
@@ -493,10 +493,10 @@ jobs:
               restrictedApprovers.has(login),
             );
 
-            if (disallowedRestrictedApprovers.length > 0 && !isActionGeneratedForce) {
+            if (disallowedRestrictedApprovers.length > 0 && !isActionGeneratedRelease) {
               core.setFailed(
                 [
-                  `Restricted release-automation identities may only approve action-generated [Force] PRs.`,
+                  `Restricted release-automation identities may only approve action-generated [Release] PRs.`,
                   "",
                   `Detected disallowed approval(s): ${disallowedRestrictedApprovers.join(", ")}`,
                   "What to do:",
@@ -507,11 +507,11 @@ jobs:
               return;
             }
 
-            if (isActionGeneratedForce) {
+            if (isActionGeneratedRelease) {
               if (pr.user.login !== expectedActionAuthor) {
                 core.setFailed(
                   [
-                    `Action-generated [Force] PR must be created by ${expectedActionAuthor}.`,
+                    `Action-generated [Release] PR must be created by ${expectedActionAuthor}.`,
                     "",
                     `Detected PR author: ${pr.user.login}`,
                     "What to do:",
@@ -521,25 +521,25 @@ jobs:
                 );
                 return;
               }
-              core.info("Automation policy satisfied for action-generated [Force] PR.");
+              core.info("Automation policy satisfied for action-generated [Release] PR.");
               return;
             }
 
             // Inverse guard: if noodle-bucket-bot is the author, the PR MUST be
-            // an action-generated [Force] release. This blocks a leaked
+            // an action-generated [Release] PR. This blocks a leaked
             // VERSION_BUMP_TOKEN from being used to open arbitrary PRs that
             // would otherwise look benign (e.g. a [Patch] PR opened by the bot).
             if (pr.user.login === expectedActionAuthor) {
               core.setFailed(
                 [
-                  `${expectedActionAuthor} may only author action-generated [Force] release PRs.`,
+                  `${expectedActionAuthor} may only author action-generated [Release] PRs.`,
                   "",
                   `Detected PR title:    ${pr.title}`,
                   `Detected PR head ref: ${pr.head.ref}`,
                   `Detected PR head repo: ${pr.head.repo.full_name}`,
                   "",
-                  "Required for an action-generated [Force] PR:",
-                  "- Title must start with '[Force]'",
+                  "Required for an action-generated [Release] PR:",
+                  "- Title must start with '[Release]'",
                   "- Head ref must be 'ci/version-bump-main'",
                   "- Head and base must be the same repository",
                   "",

--- a/.github/workflows/release-pipeline-gate.yml
+++ b/.github/workflows/release-pipeline-gate.yml
@@ -1,23 +1,23 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
 
-# Required status check named 'release-pipeline-gate' on every PR with a
-# recognized release-prefix title.
+# Two jobs run on every PR targeting main:
 #
-# Posts a commit status on the PR's head SHA reflecting whether the release
-# pipeline is currently free:
+# 1. set-gate  — posts a 'release-pipeline-gate' commit status.
+#      - [None]/[Release]: always 'success'.
+#      - [Patch]/[Minor]/[Major]: 'success' when no release PR
+#        (head=ci/version-bump-main) is open; 'pending' otherwise.
+#    The bump workflow keeps this fresh dynamically (pending → success
+#    around each release). If it fails mid-run, gates stay 'pending'
+#    (stay-blocked policy) until a human investigates.
 #
-#   - [None]  : always 'success' (does not bump or release).
-#   - [Release]: always 'success' (it IS the release, does not gate itself).
-#   - [Patch]/[Minor]/[Major]: 'success' when no release PR
-#     (head=ci/version-bump-main) is open; 'pending' otherwise.
+# 2. check-release-secrets  — validates release-bot credentials on
+#    [Patch]/[Minor]/[Major] PRs so a broken token blocks the PR
+#    BEFORE it merges, not after. Safe to use pull_request_target here
+#    because no code from the head ref is ever checked out or executed.
 #
-# The bump workflow (`Bump Version On Merge`) keeps this status fresh
-# dynamically: it flips every other open source PR's gate to 'pending' the
-# moment a source PR merges, and back to 'success' once the release PR has
-# successfully merged. If the bump workflow fails before reaching the
-# success step, gates intentionally stay 'pending' (stay-blocked policy)
-# until a human investigates.
+# Both jobs use pull_request_target so they have access to secrets and
+# can post statuses on PRs from forks.
 #
 # Operator guide (including how to manually clear a stuck gate):
 #   .github/RELEASE_AUTOMATION.md
@@ -129,3 +129,60 @@ jobs:
               description: "No active release PR; clear to merge",
             });
             core.info(`PR #${pr.number} gated success: no active release PR.`);
+
+  # Validates that the secrets required by the bump workflow are present and
+  # working on every [Patch]/[Minor]/[Major] PR, so a broken or expired token
+  # blocks the PR before it merges rather than after.
+  # Safe: no checkout or execution of head-ref code; only API calls.
+  check-release-secrets:
+    if: |
+      startsWith(github.event.pull_request.title, '[Patch]') ||
+      startsWith(github.event.pull_request.title, '[Minor]') ||
+      startsWith(github.event.pull_request.title, '[Major]')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate VERSION_BUMP_TOKEN
+        env:
+          VERSION_BUMP_TOKEN: ${{ secrets.VERSION_BUMP_TOKEN }}
+        run: |
+          set -euo pipefail
+          expected_login="noodle-bucket-bot"
+
+          if [ -z "${VERSION_BUMP_TOKEN:-}" ]; then
+            echo "::error title=Missing VERSION_BUMP_TOKEN::The release pipeline cannot run. Set the VERSION_BUMP_TOKEN secret to a PAT from ${expected_login} (repo scope for classic PAT, or fine-grained Contents + Pull requests: Read and write)."
+            exit 1
+          fi
+
+          if ! login="$(GH_TOKEN="${VERSION_BUMP_TOKEN}" gh api user --jq .login 2>&1)"; then
+            echo "::error title=Expired or revoked VERSION_BUMP_TOKEN::Token authentication failed — the PAT for ${expected_login} has likely expired or been revoked. Renew it and update the VERSION_BUMP_TOKEN secret before merging this PR."
+            echo "Response: ${login}"
+            exit 1
+          fi
+
+          if [ "$login" != "$expected_login" ]; then
+            echo "::error title=Wrong VERSION_BUMP_TOKEN owner::Token belongs to '${login}', expected '${expected_login}'. Update VERSION_BUMP_TOKEN to a PAT from ${expected_login}."
+            exit 1
+          fi
+
+          echo "VERSION_BUMP_TOKEN is valid (authenticated as ${login})."
+
+      - name: Check approver app secrets are set
+        env:
+          APPROVER_APP_ID: ${{ secrets.APPROVER_APP_ID }}
+          APPROVER_APP_PRIVATE_KEY: ${{ secrets.APPROVER_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          failed=0
+
+          if [ -z "${APPROVER_APP_ID:-}" ]; then
+            echo "::error title=Missing APPROVER_APP_ID::Set the APPROVER_APP_ID secret to the bucket-release-approver GitHub App ID."
+            failed=1
+          fi
+
+          if [ -z "${APPROVER_APP_PRIVATE_KEY:-}" ]; then
+            echo "::error title=Missing APPROVER_APP_PRIVATE_KEY::Set the APPROVER_APP_PRIVATE_KEY secret to the bucket-release-approver GitHub App private key."
+            failed=1
+          fi
+
+          [ "$failed" -eq 0 ] && echo "Approver app secrets are set." || exit 1

--- a/.github/workflows/release-pipeline-gate.yml
+++ b/.github/workflows/release-pipeline-gate.yml
@@ -8,7 +8,7 @@
 # pipeline is currently free:
 #
 #   - [None]  : always 'success' (does not bump or release).
-#   - [Force] : always 'success' (it IS the release, does not gate itself).
+#   - [Release]: always 'success' (it IS the release, does not gate itself).
 #   - [Patch]/[Minor]/[Major]: 'success' when no release PR
 #     (head=ci/version-bump-main) is open; 'pending' otherwise.
 #
@@ -51,7 +51,7 @@ jobs:
       startsWith(github.event.pull_request.title, '[Minor]') ||
       startsWith(github.event.pull_request.title, '[Major]') ||
       startsWith(github.event.pull_request.title, '[None]') ||
-      startsWith(github.event.pull_request.title, '[Force]')
+      startsWith(github.event.pull_request.title, '[Release]')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -62,7 +62,7 @@ jobs:
             const pr = context.payload.pull_request;
             const sha = pr.head.sha;
             const isNone = pr.title.startsWith("[None]");
-            const isForce = pr.title.startsWith("[Force]");
+            const isRelease = pr.title.startsWith("[Release]");
 
             // [None] PRs do not interact with the release pipeline.
             if (isNone) {
@@ -78,10 +78,10 @@ jobs:
               return;
             }
 
-            // The auto-generated [Force] release PR IS the in-flight release;
+            // The auto-generated [Release] PR IS the in-flight release;
             // it does not block itself. It must still satisfy the required
             // gate status, so post 'success' on it directly.
-            if (isForce) {
+            if (isRelease) {
               await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -90,7 +90,7 @@ jobs:
                 context: "release-pipeline-gate",
                 description: "Release PR; gate does not apply to itself",
               });
-              core.info(`PR #${pr.number} is [Force]; gate set to success (does not gate itself).`);
+              core.info(`PR #${pr.number} is [Release]; gate set to success (does not gate itself).`);
               return;
             }
 

--- a/.github/workflows/token-health-check.yml
+++ b/.github/workflows/token-health-check.yml
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+#
+# Proactive health check for secrets used by the release pipeline.
+# Runs on a schedule and on manual trigger so token expiry is caught
+# BEFORE a [Patch]/[Minor]/[Major] PR merges and needs the token.
+#
+# If this workflow fails:
+#   1. Renew the PAT for noodle-bucket-bot (repo scope for classic PAT,
+#      or fine-grained: Contents: Read and write + Pull requests: Read and write).
+#   2. Update the VERSION_BUMP_TOKEN repository secret with the new PAT.
+#   3. Re-run this workflow to confirm.
+#
+# See .github/RELEASE_AUTOMATION.md for the full release pipeline overview.
+
+name: Release Bot Token Health Check
+
+on:
+  schedule:
+    # Run every Monday at 09:00 UTC. Adjust to taste, but at least weekly
+    # is recommended since classic PATs can expire with little notice.
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-version-bump-token:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate VERSION_BUMP_TOKEN
+        env:
+          VERSION_BUMP_TOKEN: ${{ secrets.VERSION_BUMP_TOKEN }}
+        run: |
+          set -euo pipefail
+          expected_login="noodle-bucket-bot"
+
+          if [ -z "${VERSION_BUMP_TOKEN:-}" ]; then
+            echo "::error title=Missing VERSION_BUMP_TOKEN::The VERSION_BUMP_TOKEN secret is not set. Set it to a PAT from ${expected_login} with repo scope (classic) or Contents + Pull requests: Read and write (fine-grained)."
+            exit 1
+          fi
+
+          if ! login="$(GH_TOKEN="${VERSION_BUMP_TOKEN}" gh api user --jq .login 2>&1)"; then
+            echo "::error title=Invalid VERSION_BUMP_TOKEN::Token authentication failed — it is likely expired or revoked. Renew the PAT for ${expected_login} and update the VERSION_BUMP_TOKEN secret."
+            echo "Response: ${login}"
+            exit 1
+          fi
+
+          if [ "$login" != "$expected_login" ]; then
+            echo "::error title=Wrong VERSION_BUMP_TOKEN owner::Token belongs to '${login}', expected '${expected_login}'. Update VERSION_BUMP_TOKEN to a PAT from ${expected_login}."
+            exit 1
+          fi
+
+          echo "VERSION_BUMP_TOKEN is valid (authenticated as ${login})."
+
+      - name: Validate APPROVER_APP secrets are set
+        env:
+          APPROVER_APP_ID: ${{ secrets.APPROVER_APP_ID }}
+          APPROVER_APP_PRIVATE_KEY: ${{ secrets.APPROVER_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          failed=0
+
+          if [ -z "${APPROVER_APP_ID:-}" ]; then
+            echo "::error title=Missing APPROVER_APP_ID::Set the APPROVER_APP_ID repository secret to the bucket-release-approver GitHub App ID."
+            failed=1
+          else
+            echo "APPROVER_APP_ID is set."
+          fi
+
+          if [ -z "${APPROVER_APP_PRIVATE_KEY:-}" ]; then
+            echo "::error title=Missing APPROVER_APP_PRIVATE_KEY::Set the APPROVER_APP_PRIVATE_KEY repository secret to the bucket-release-approver GitHub App private key."
+            failed=1
+          else
+            echo "APPROVER_APP_PRIVATE_KEY is set."
+          fi
+
+          exit "$failed"
+
+      - name: Mint and validate approver app token
+        id: approver_token
+        # actions/create-github-app-token v3.1.1 (2026-04-11)
+        # refs/tags/v3.1.1 -> 1b10c78c7865c340bc4f6099eb2f838309f1e8c3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3
+        with:
+          app-id: ${{ secrets.APPROVER_APP_ID }}
+          private-key: ${{ secrets.APPROVER_APP_PRIVATE_KEY }}
+
+      - name: Confirm approver app token resolves correct identity
+        env:
+          GH_TOKEN: ${{ steps.approver_token.outputs.token }}
+          EXPECTED_SLUG: bucket-release-approver
+        run: |
+          set -euo pipefail
+
+          slug="$(gh api /app --jq .slug 2>&1)" || {
+            echo "::error title=Approver app token invalid::Could not authenticate with the minted token. The APPROVER_APP_PRIVATE_KEY may be revoked or the App may have been suspended."
+            echo "Response: ${slug}"
+            exit 1
+          }
+
+          if [ "$slug" != "$EXPECTED_SLUG" ]; then
+            echo "::error title=Wrong approver app identity::App slug is '${slug}', expected '${EXPECTED_SLUG}'. Check APPROVER_APP_ID and APPROVER_APP_PRIVATE_KEY point to the right App."
+            exit 1
+          fi
+
+          echo "Approver app token is valid (slug: ${slug})."


### PR DESCRIPTION
## Summary

Same root cause as the defensive-check fix in 6bb4666: the `[Force]`
code path does not run `actions/checkout`, so `gh release view` and
`gh release create` had no local `.git` to detect the repository from
and failed with:

```
failed to run git: fatal: not a git repository (or any of the parent
directories): .git
```

This caused the v2.2.2 release-tag step ([run 24942656965](https://github.com/Noodle-Bytes/bucket/actions/runs/24942656965))
to fail after the auto-generated `[Force]` PR for v2.2.2 had successfully
merged. Result: `pyproject.toml` on `main` is correctly at `2.2.2`, but no
`v2.2.2` GitHub release exists.

I should have caught this when fixing the defensive check — same class of
bug, same workflow, just hidden in the `[Force]` code path. I audited the
remaining `gh` calls this time:

| Call site | Pre-checkout? | Status |
|-----------|---------------|--------|
| Defensive check | Yes | Already fixed (`GH_REPO` set) |
| Approve `gh api repos/...` | Yes (App approval) | OK — uses explicit repo path |
| Merge loop `gh pr view` / `gh pr merge` | No (post-checkout) | OK |
| Release create | Yes ([Force] path) | **Fixed by this PR** |

## Fix

`GH_REPO=${{ github.repository }}` on the release-create step.

## Recovery for the missed v2.2.2 release

This PR alone does not create v2.2.2. Recovery sequence:

1. Manually create the v2.2.2 release pointing at the `[Force]` PR's
   merge commit. Two equivalent options:

   ```bash
   gh release create v2.2.2 \
     --repo Noodle-Bytes/bucket \
     --target 4918a276fc4a17b81422b80ea5e0c70d9c9c2b9b \
     --title v2.2.2 \
     --generate-notes
   ```

   Or via UI: Releases → Draft a new release → Tag `v2.2.2` (new tag) →
   Target: `4918a27` → Generate release notes → Publish.

2. Merge this PR. It is `[Patch]`, so it will trigger the bump workflow
   to release v2.2.3 (with the now-fixed release-create step).

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, `Bump Version On Merge` for this PR completes
      successfully end-to-end (both source-PR run and `[Force]`
      release-tag run).
- [ ] v2.2.3 release tag and GitHub release are created.
- [ ] PR #114's `release-pipeline-gate` resets to `success`.