### PR TITLE
[Patch] upgrade github-script to v9 and scope Pages deploy to releases

### DIFF
--- a/.github/workflows/bump-version-on-merge.yml
+++ b/.github/workflows/bump-version-on-merge.yml
@@ -79,7 +79,7 @@ jobs:
       # gate while this workflow is still spinning up.
       - name: Set release pipeline gate to pending on open source PRs
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           MERGED_PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
@@ -358,7 +358,7 @@ jobs:
       # human investigates (per the chosen "stay-blocked" recovery policy).
       - name: Set release pipeline gate to success on open source PRs
         if: contains(fromJSON('["patch","minor","major"]'), steps.pr_meta.outputs.bump)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           MERGED_PR_NUMBER: ${{ github.event.pull_request.number }}
         with:
@@ -417,7 +417,7 @@ jobs:
         id: version_meta
         env:
           TARGET_SHA: ${{ steps.release_target_force.outputs.sha }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const targetSha = process.env.TARGET_SHA;

--- a/.github/workflows/deploy-viewer.yml
+++ b/.github/workflows/deploy-viewer.yml
@@ -4,8 +4,12 @@
 name: Deploy Viewer to GitHub Pages
 
 on:
-  push:
+  # Only deploy when a [Release] PR merges to main, not on every commit.
+  # Source PRs ([Patch]/[Minor]/[Major]) do not change the public-facing
+  # site; only the version-bump release PR should trigger a deploy.
+  pull_request_target:
     branches: ["main"]
+    types: [closed]
   workflow_dispatch:
 
 permissions:
@@ -19,6 +23,10 @@ concurrency:
 
 jobs:
   build:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.title, '[Release]'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Block manual version changes in PRs
         if: ${{ !startsWith(github.event.pull_request.title, '[Release]') }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -182,7 +182,7 @@ jobs:
 
       - name: Release mode requires version-only changes in tracked files
         if: ${{ startsWith(github.event.pull_request.title, '[Release]') }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -452,7 +452,7 @@ jobs:
             core.info("[Release] version-only changes validated and version files are synchronized.");
 
       - name: Enforce automation policy for action-generated release PRs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/release-pipeline-gate.yml
+++ b/.github/workflows/release-pipeline-gate.yml
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Set initial release pipeline gate status
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;


### PR DESCRIPTION
## Summary

Two improvements on top of the fixes already landed in #139.

### 1. `actions/github-script` v7 → v9 (Node 20 → Node 24)

Addresses the deprecation warning visible in CI:

> Node.js 20 actions are deprecated. Actions will be forced to run with
> Node.js 24 by default starting June 2nd, 2026.

Updated 7 occurrences across `bump-version-on-merge.yml`,
`pr-title-check.yml`, and `release-pipeline-gate.yml`.

### 2. GitHub Pages deploy scoped to `[Release]` PRs only

Previously `deploy-viewer.yml` triggered on every `push` to `main`,
so merging a `[Patch]` source PR immediately kicked off a full Pages
build and deploy — even though no public-facing content changed.

Changed to `pull_request_target` (closed) with the condition:

```
github.event.pull_request.merged == true
&& startsWith(github.event.pull_request.title, '[Release]')
```

Pages now deploys exactly when a new version is released. Manual
`workflow_dispatch` trigger is retained for emergency redeployments.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: bump workflow creates `[Release] release v2.2.3` PR.
- [ ] `[Release]` PR merges → Pages deploy runs.
- [ ] Merge of this source PR itself → Pages deploy does NOT run.