### PR TITLE
[Patch] add top-level coverage info panel and dark-theme UI polish

### DIFF
--- a/viewer/src/components/CoverageLoadingOverlay.tsx
+++ b/viewer/src/components/CoverageLoadingOverlay.tsx
@@ -4,7 +4,7 @@
  */
 
 import { LoadingOutlined } from "@ant-design/icons";
-import { Progress, Spin, Typography } from "antd";
+import { Spin, Typography } from "antd";
 import Theme from "@/providers/Theme";
 import type { LoadingProgress } from "@/hooks/useFileLoader";
 
@@ -43,13 +43,12 @@ export function CoverageLoadingOverlay({ open, loadingProgress }: CoverageLoadin
                 const muted = theme.theme.colors.desaturatedtxt.value;
                 const hasCounts = loadingProgress !== null && loadingProgress.total > 0;
                 const isApplying = loadingProgress?.phase === "applying";
-                const pct =
-                    hasCounts && !isApplying
-                        ? archiveReadPercent(
-                              loadingProgress!.completed,
-                              loadingProgress!.total,
-                          )
-                        : null;
+                const pct = hasCounts
+                    ? archiveReadPercent(
+                          loadingProgress!.completed,
+                          loadingProgress!.total,
+                      )
+                    : null;
 
                 return (
                     <div
@@ -62,7 +61,7 @@ export function CoverageLoadingOverlay({ open, loadingProgress }: CoverageLoadin
                         aria-valuetext={
                             hasCounts
                                 ? isApplying
-                                    ? "Applying to viewer"
+                                    ? `All ${loadingProgress!.total} archives read; applying to viewer`
                                     : `${loadingProgress!.completed} of ${loadingProgress!.total} archives read`
                                 : "Loading"
                         }
@@ -94,93 +93,58 @@ export function CoverageLoadingOverlay({ open, loadingProgress }: CoverageLoadin
                                     fontWeight: 600,
                                     textAlign: "center",
                                 }}>
-                                {isApplying ? "Finishing up" : "Loading coverage"}
+                                Loading coverage
                             </Typography.Title>
 
                             {hasCounts ? (
-                                isApplying ? (
-                                    <>
+                                <>
+                                    <div
+                                        style={{
+                                            marginBottom: 4,
+                                            height: 8,
+                                            borderRadius: 999,
+                                            backgroundColor: border,
+                                            overflow: "hidden",
+                                        }}
+                                    >
                                         <div
                                             style={{
-                                                display: "flex",
-                                                flexDirection: "column",
-                                                alignItems: "center",
-                                                gap: 18,
-                                                padding: "8px 0 4px",
-                                            }}>
-                                            <Spin
-                                                size="large"
-                                                indicator={
-                                                    <LoadingOutlined
-                                                        spin
-                                                        style={{ fontSize: 36, color: accent }}
-                                                    />
-                                                }
-                                            />
-                                        </div>
-                                        <Typography.Text
-                                            style={{
-                                                display: "block",
-                                                fontSize: 15,
-                                                lineHeight: 1.5,
-                                                color: titleColor,
-                                                textAlign: "center",
-                                            }}>
-                                            {loadingProgress!.applyingKind === "merge"
-                                                ? "Merging coverage from all archives into a single record."
-                                                : `Preparing ${loadingProgress!.total} archives in the viewer (records, tree, and views).`}
-                                        </Typography.Text>
-                                        <Typography.Text
-                                            style={{
-                                                display: "block",
-                                                marginTop: 12,
-                                                fontSize: 13,
-                                                lineHeight: 1.45,
-                                                color: muted,
-                                                textAlign: "center",
-                                            }}>
-                                            Archive decoding is finished. This step can take a while
-                                            for very large batches and uses more memory the more
-                                            archives you load at once.
-                                        </Typography.Text>
-                                    </>
-                                ) : (
-                                    <>
-                                        <Progress
-                                            percent={pct ?? 0}
-                                            showInfo={false}
-                                            strokeColor={accent}
-                                            trailColor={border}
-                                            strokeLinecap="round"
-                                            style={{ marginBottom: 4 }}
+                                                width: `${pct ?? 0}%`,
+                                                height: "100%",
+                                                borderRadius: 999,
+                                                backgroundColor: accent,
+                                                transition: "width 0.2s ease",
+                                            }}
                                         />
-                                        <Typography.Text
-                                            style={{
-                                                display: "block",
-                                                marginTop: 14,
-                                                fontSize: 17,
-                                                fontWeight: 500,
-                                                color: titleColor,
-                                                textAlign: "center",
-                                            }}>
-                                            {loadingProgress!.completed} / {loadingProgress!.total}{" "}
-                                            archives read
-                                        </Typography.Text>
-                                        <Typography.Text
-                                            style={{
-                                                display: "block",
-                                                marginTop: 10,
-                                                fontSize: 14,
-                                                lineHeight: 1.45,
-                                                color: muted,
-                                                textAlign: "center",
-                                            }}>
-                                            The bar tracks decoded archives. After the last one, the
-                                            viewer runs a final preparation step before the UI is
-                                            ready.
-                                        </Typography.Text>
-                                    </>
-                                )
+                                    </div>
+                                    <Typography.Text
+                                        style={{
+                                            display: "block",
+                                            marginTop: 14,
+                                            fontSize: 17,
+                                            fontWeight: 500,
+                                            color: titleColor,
+                                            textAlign: "center",
+                                        }}>
+                                        {loadingProgress!.completed} / {loadingProgress!.total}{" "}
+                                        archives read
+                                    </Typography.Text>
+                                    <Typography.Text
+                                        style={{
+                                            display: "block",
+                                            marginTop: 10,
+                                            fontSize: 14,
+                                            lineHeight: 1.45,
+                                            color: muted,
+                                            textAlign: "center",
+                                        }}>
+                                        {isApplying
+                                            ? loadingProgress!.applyingKind === "merge"
+                                                ? "All files loaded. Merging and preparing the final record."
+                                                : "All files loaded. Preparing records, tree, and views."
+                                            : "Reading and decoding selected archive files."}
+                                    </Typography.Text>
+                                </>
                             ) : (
                                 <div
                                     style={{

--- a/viewer/src/features/Dashboard/index.tsx
+++ b/viewer/src/features/Dashboard/index.tsx
@@ -68,6 +68,11 @@ type RootCoverageInfo = {
     recSha: string | null;
 };
 
+type TopLevelCoverageCounts = {
+    coverpoints: number;
+    covergroups: number;
+};
+
 const ColorModeToggleButton = (props: FloatButtonProps) => {
     return (
         <Theme.Consumer>
@@ -119,30 +124,40 @@ function getReadoutSource(readout: Readout): string | null {
 }
 
 function getTopLevelCoverageInfo(
-    tree: Tree,
     node: TreeNode,
+    counts: TopLevelCoverageCounts,
 ): RootCoverageInfo {
-    let coverpoints = 0;
-    let covergroups = 0;
-
-    for (const [subNode] of tree.walk([node])) {
-        if (subNode.children?.length) {
-            covergroups += 1;
-        } else {
-            coverpoints += 1;
-        }
-    }
-
     const readout = node.data.readout as Readout;
 
     return {
         name: node.data.point?.name ?? String(node.title),
-        coverpoints,
-        covergroups,
+        coverpoints: counts.coverpoints,
+        covergroups: counts.covergroups,
         source: getReadoutSource(readout),
         defSha: getReadoutValue(readout, "get_def_sha"),
         recSha: getReadoutValue(readout, "get_rec_sha"),
     };
+}
+
+function getTopLevelCoverageCountsByKey(tree: Tree): Map<TreeKey, TopLevelCoverageCounts> {
+    const countsByKey = new Map<TreeKey, TopLevelCoverageCounts>();
+
+    for (const root of tree.getRoots()) {
+        let coverpoints = 0;
+        let covergroups = 0;
+
+        for (const [subNode] of tree.walk([root])) {
+            if (subNode.children?.length) {
+                covergroups += 1;
+            } else {
+                coverpoints += 1;
+            }
+        }
+
+        countsByKey.set(root.key, { coverpoints, covergroups });
+    }
+
+    return countsByKey;
 }
 
 function CoverageInfoField({
@@ -556,10 +571,24 @@ export default function Dashboard({
         return { source: null, source_key: null };
     }, [tree, viewKey]);
 
+    const topLevelCoverageCountsByKey = useMemo(
+        () => getTopLevelCoverageCountsByKey(tree),
+        [tree],
+    );
+
     const topLevelCoverageInfo = useMemo(() => {
         const infoNode = getTopLevelInfoNode(tree, viewKey);
-        return infoNode ? getTopLevelCoverageInfo(tree, infoNode) : null;
-    }, [tree, viewKey]);
+        if (!infoNode) {
+            return null;
+        }
+
+        const counts = topLevelCoverageCountsByKey.get(infoNode.key);
+        if (!counts) {
+            return null;
+        }
+
+        return getTopLevelCoverageInfo(infoNode, counts);
+    }, [tree, viewKey, topLevelCoverageCountsByKey]);
 
     const selectedViewContent = useMemo(() => {
         if (isEmpty) {

--- a/viewer/src/features/Dashboard/index.tsx
+++ b/viewer/src/features/Dashboard/index.tsx
@@ -24,6 +24,8 @@ import {
 } from "antd";
 import {
     BgColorsOutlined,
+    CaretDownOutlined,
+    CaretRightOutlined,
     ClearOutlined,
     EditOutlined,
     ExportOutlined,
@@ -36,7 +38,7 @@ import Tree, { TreeKey, TreeNode } from "./lib/tree";
 import Sider from "./components/Sider";
 import EmptyState from "./components/EmptyState";
 import { antTheme, view } from "./theme";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { BreadcrumbItemType } from "antd/lib/breadcrumb/Breadcrumb";
 import { PointGrid, PointSummaryGrid } from "./lib/coveragegrid";
 import { PointPivotView } from "./lib/pivottable";
@@ -55,6 +57,15 @@ type RecordTableRow = {
     sourceKind: string;
     recordIndex: number;
     isLoaded: boolean;
+};
+
+type RootCoverageInfo = {
+    name: string;
+    coverpoints: number;
+    covergroups: number;
+    source: string | null;
+    defSha: string | null;
+    recSha: string | null;
 };
 
 const ColorModeToggleButton = (props: FloatButtonProps) => {
@@ -79,6 +90,201 @@ const ColorModeToggleButton = (props: FloatButtonProps) => {
         </Theme.Consumer>
     );
 };
+
+function getReadoutValue(readout: Readout, getter: keyof Pick<Readout, "get_def_sha" | "get_rec_sha">) {
+    try {
+        return readout[getter]();
+    } catch {
+        return null;
+    }
+}
+
+function getReadoutSource(readout: Readout): string | null {
+    try {
+        const source = readout.get_source?.();
+        const sourceKey = readout.get_source_key?.();
+        if (source && sourceKey) {
+            return `${source}[${sourceKey}]`;
+        }
+        if (source) {
+            return source;
+        }
+        if (sourceKey) {
+            return `[${sourceKey}]`;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+function getTopLevelCoverageInfo(
+    tree: Tree,
+    node: TreeNode,
+): RootCoverageInfo {
+    let coverpoints = 0;
+    let covergroups = 0;
+
+    for (const [subNode] of tree.walk([node])) {
+        if (subNode.children?.length) {
+            covergroups += 1;
+        } else {
+            coverpoints += 1;
+        }
+    }
+
+    const readout = node.data.readout as Readout;
+
+    return {
+        name: node.data.point?.name ?? String(node.title),
+        coverpoints,
+        covergroups,
+        source: getReadoutSource(readout),
+        defSha: getReadoutValue(readout, "get_def_sha"),
+        recSha: getReadoutValue(readout, "get_rec_sha"),
+    };
+}
+
+function CoverageInfoField({
+    label,
+    value,
+    mono = false,
+    colors,
+}: {
+    label: string;
+    value: string | number | null;
+    mono?: boolean;
+    colors: ThemeType["theme"]["colors"];
+}) {
+    const displayValue = value === null || value === "" ? "Unknown" : value;
+
+    return (
+        <>
+            <Typography.Text style={{ color: colors.desaturatedtxt.value, fontSize: 12 }}>
+                {label}
+            </Typography.Text>
+            <Typography.Text
+                style={{
+                    color: colors.primarytxt.value,
+                    fontSize: 12,
+                    fontFamily: mono ? "monospace" : undefined,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                }}>
+                {displayValue}
+            </Typography.Text>
+        </>
+    );
+}
+
+function TopLevelCoverageInfoPanel({ info }: { info: RootCoverageInfo }) {
+    const [isCollapsed, setIsCollapsed] = useState(false);
+
+    return (
+        <Theme.Consumer>
+            {({ theme }) => {
+                const colors = theme.theme.colors;
+                return (
+                    <section
+                        style={{
+                            margin: "6px 10px 8px",
+                            border: `1px solid ${colors.lowlightbg.value}`,
+                            backgroundColor: colors.secondarybg.value,
+                        }}>
+                        <button
+                            type="button"
+                            aria-expanded={!isCollapsed}
+                            onClick={() => setIsCollapsed((current) => !current)}
+                            style={{
+                                width: "100%",
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 6,
+                                border: 0,
+                                padding: "5px 8px",
+                                color: colors.primarytxt.value,
+                                background: "transparent",
+                                cursor: "pointer",
+                                fontSize: 12,
+                                fontWeight: 600,
+                                textAlign: "left",
+                            }}>
+                            {isCollapsed ? <CaretRightOutlined /> : <CaretDownOutlined />}
+                            Coverage Info
+                        </button>
+                        {!isCollapsed && (
+                            <div
+                                style={{
+                                    display: "grid",
+                                    gridTemplateColumns: "max-content minmax(0, 1fr) max-content minmax(0, 1fr)",
+                                    gap: "4px 14px",
+                                    padding: "0 8px 8px 24px",
+                                }}>
+                                <CoverageInfoField label="Name" value={info.name} colors={colors} />
+                                <CoverageInfoField
+                                    label="Source"
+                                    value={info.source}
+                                    colors={colors}
+                                />
+                                <CoverageInfoField
+                                    label="Coverpoints"
+                                    value={info.coverpoints.toLocaleString()}
+                                    colors={colors}
+                                />
+                                <CoverageInfoField
+                                    label="Covergroups"
+                                    value={info.covergroups.toLocaleString()}
+                                    colors={colors}
+                                />
+                                <CoverageInfoField
+                                    label="Definition SHA"
+                                    value={info.defSha}
+                                    mono
+                                    colors={colors}
+                                />
+                                <CoverageInfoField
+                                    label="Record SHA"
+                                    value={info.recSha}
+                                    mono
+                                    colors={colors}
+                                />
+                            </div>
+                        )}
+                    </section>
+                );
+            }}
+        </Theme.Consumer>
+    );
+}
+
+function getTopLevelInfoNode(tree: Tree, viewKey: TreeKey): TreeNode | null {
+    const roots = tree.getRoots();
+    if (viewKey === Tree.ROOT) {
+        return roots.length === 1 ? roots[0] : null;
+    }
+
+    return roots.find((node) => node.key === viewKey) ?? null;
+}
+
+function withTopLevelInfoPanel({
+    content,
+    info,
+}: {
+    content: ReactNode;
+    info: RootCoverageInfo | null;
+}) {
+    if (!info) {
+        return content;
+    }
+
+    return (
+        <>
+            <TopLevelCoverageInfoPanel info={info} />
+            {content}
+        </>
+    );
+}
 
 type BreadCrumbMenuProps = {
     pathNode: TreeDataNode;
@@ -350,6 +556,11 @@ export default function Dashboard({
         return { source: null, source_key: null };
     }, [tree, viewKey]);
 
+    const topLevelCoverageInfo = useMemo(() => {
+        const infoNode = getTopLevelInfoNode(tree, viewKey);
+        return infoNode ? getTopLevelCoverageInfo(tree, infoNode) : null;
+    }, [tree, viewKey]);
+
     const selectedViewContent = useMemo(() => {
         if (isEmpty) {
             return <EmptyState logoSrc={logoSrc} onOpenFile={onOpenFile} />;
@@ -362,30 +573,55 @@ export default function Dashboard({
 
         switch (currentContentKey) {
             case "Pivot":
-                return <PointPivotView node={currentNode} />;
-            case "Summary":
+                return withTopLevelInfoPanel({
+                    content: <PointPivotView node={currentNode} />,
+                    info: topLevelCoverageInfo,
+                });
+            case "Summary": {
                 if (summaryViewMode === "donut") {
-                    return (
+                    const donut = (
                         <CoverageDonut
                             tree={tree}
                             node={currentNode}
                             setSelectedTreeKeys={onSelect}
                         />
                     );
+                    return withTopLevelInfoPanel({
+                        content: donut,
+                        info: topLevelCoverageInfo,
+                    });
                 }
-                return (
+                const summary = (
                     <PointSummaryGrid
                         tree={tree}
                         node={currentNode}
                         setSelectedTreeKeys={onSelect}
                     />
                 );
+                return withTopLevelInfoPanel({
+                    content: summary,
+                    info: topLevelCoverageInfo,
+                });
+            }
             case "Point":
-                return <PointGrid node={currentNode} />;
+                return withTopLevelInfoPanel({
+                    content: <PointGrid node={currentNode} />,
+                    info: topLevelCoverageInfo,
+                });
             default:
                 throw new Error("Invalid view!?");
         }
-    }, [viewKey, currentContentKey, tree, isEmpty, onOpenFile, logoSrc, summaryViewMode, onSelect]);
+    }, [
+        viewKey,
+        currentContentKey,
+        tree,
+        isEmpty,
+        onOpenFile,
+        logoSrc,
+        summaryViewMode,
+        onSelect,
+        topLevelCoverageInfo,
+    ]);
 
     const applyLoadedEdits = () => {
         if (!onSetLoadedRecords) {

--- a/viewer/src/features/Dashboard/lib/coveragedonut.tsx
+++ b/viewer/src/features/Dashboard/lib/coveragedonut.tsx
@@ -328,7 +328,17 @@ export function CoverageDonut({
             {(themeContextRaw) => {
                 const isRoot = node.key === CoverageTree.ROOT;
                 const roots = tree.getRoots();
-                if (isRoot && roots.length > 1) {
+                if (isRoot) {
+                    if (roots.length === 1) {
+                        return (
+                            <CoverageDonutInner
+                                node={roots[0]}
+                                themeContext={themeContextRaw}
+                                setSelectedTreeKeys={setSelectedTreeKeys}
+                            />
+                        );
+                    }
+
                     // Grid layout for multiple root donuts
                     return (
                         <div

--- a/viewer/src/features/Dashboard/lib/coveragegrid.tsx
+++ b/viewer/src/features/Dashboard/lib/coveragegrid.tsx
@@ -4,7 +4,7 @@
  */
 
 import CoverageTree, { PointNode } from "./coveragetree";
-import { Alert, Button, Modal, Select, Space, Table, TableProps, Typography } from "antd";
+import { Alert, Button, ConfigProvider, Modal, Select, Space, Table, TableProps, Typography } from "antd";
 import { view } from "../theme";
 import { TreeKey } from "./tree";
 import { Theme as ThemeType } from "@/theme";
@@ -759,20 +759,34 @@ export function PointGrid({ node }: PointGridProps) {
     return (
         <Theme.Consumer>
             {({ theme }) => {
+                const colors = theme.theme.colors;
                 const banner = isLargeDataset ? (
                     <Alert
-                        style={{ marginBottom: 10 }}
+                        style={{
+                            marginBottom: 10,
+                            color: colors.primarytxt.value,
+                            backgroundColor: colors.secondarybg.value,
+                            borderColor: isLargeMode
+                                ? colors.accentbg.value
+                                : colors.lowlightbg.value,
+                        }}
                         showIcon
                         type={isLargeMode ? "warning" : "info"}
                         message={
-                            isLargeMode
-                                ? `Large dataset mode active (${model.rowCount.toLocaleString()} rows).`
-                                : `Full features forced for ${model.rowCount.toLocaleString()} rows.`
+                            <Typography.Text
+                                strong
+                                style={{ color: colors.saturatedtxt.value }}>
+                                {isLargeMode
+                                    ? `Large dataset mode active (${model.rowCount.toLocaleString()} rows).`
+                                    : `Full features forced for ${model.rowCount.toLocaleString()} rows.`}
+                            </Typography.Text>
                         }
                         description={
-                            isLargeMode
-                                ? `Optimized rendering is enabled above ${POINT_FULL_FEATURE_ROW_LIMIT.toLocaleString()} rows.`
-                                : "Optimized large mode is available if performance drops."
+                            <Typography.Text style={{ color: colors.primarytxt.value }}>
+                                {isLargeMode
+                                    ? `Optimized rendering is enabled above ${POINT_FULL_FEATURE_ROW_LIMIT.toLocaleString()} rows.`
+                                    : "Optimized large mode is available if performance drops."}
+                            </Typography.Text>
                         }
                         action={
                             isLargeMode ? (
@@ -789,47 +803,74 @@ export function PointGrid({ node }: PointGridProps) {
                 ) : null;
 
                 const largeControls = isLargeMode ? (
-                    <Space wrap style={{ marginBottom: 10 }}>
-                        <Typography.Text strong>Large mode controls:</Typography.Text>
-                        <Select
-                            size="small"
-                            value={largeGoalFilter}
-                            onChange={(value) => setLargeGoalFilter(value)}
-                            options={largeGoalOptions}
-                            style={{ minWidth: 210 }}
-                        />
-                        <Select
-                            size="small"
-                            value={largeHitFilter}
-                            onChange={(value) => setLargeHitFilter(value as HitClassFilter)}
-                            options={[
-                                { label: "All hit states", value: "all" },
-                                { label: "Full", value: "full" },
-                                { label: "Partial", value: "partial" },
-                                { label: "Empty", value: "empty" },
-                                { label: "Illegal", value: "illegal" },
-                                { label: "Ignore", value: "ignore" },
-                            ]}
-                            style={{ minWidth: 160 }}
-                        />
-                        <Select
-                            size="small"
-                            value={largeSort}
-                            onChange={(value) => setLargeSort(value as LargeSortOption)}
-                            options={[
-                                { label: "Bucket (asc)", value: "bucket_asc" },
-                                { label: "Bucket (desc)", value: "bucket_desc" },
-                                { label: "Hits (desc)", value: "hits_desc" },
-                                { label: "Hits (asc)", value: "hits_asc" },
-                                { label: "Hit % (desc)", value: "ratio_desc" },
-                                { label: "Hit % (asc)", value: "ratio_asc" },
-                            ]}
-                            style={{ minWidth: 150 }}
-                        />
-                        <Typography.Text type="secondary">
-                            Showing {largeDataSource.length.toLocaleString()} of {model.rowCount.toLocaleString()} rows
-                        </Typography.Text>
-                    </Space>
+                    <ConfigProvider
+                        theme={{
+                            token: {
+                                colorText: colors.primarytxt.value,
+                                colorTextPlaceholder: colors.desaturatedtxt.value,
+                                colorBgElevated: colors.tertiarybg.value,
+                                controlItemBgHover: colors.highlightbg.value,
+                                controlItemBgActive: colors.lowlightbg.value,
+                                colorBorder: colors.lowlightbg.value,
+                            },
+                            components: {
+                                Select: {
+                                    colorBgContainer: colors.tertiarybg.value,
+                                    colorText: colors.primarytxt.value,
+                                    colorTextPlaceholder: colors.desaturatedtxt.value,
+                                    colorBorder: colors.lowlightbg.value,
+                                    optionSelectedBg: colors.lowlightbg.value,
+                                    optionActiveBg: colors.highlightbg.value,
+                                    selectorBg: colors.tertiarybg.value,
+                                },
+                            },
+                        }}>
+                        <Space wrap style={{ marginBottom: 10, color: colors.primarytxt.value }}>
+                            <Typography.Text
+                                strong
+                                style={{ color: colors.primarytxt.value }}>
+                                Large mode controls:
+                            </Typography.Text>
+                            <Select
+                                size="small"
+                                value={largeGoalFilter}
+                                onChange={(value) => setLargeGoalFilter(value)}
+                                options={largeGoalOptions}
+                                style={{ minWidth: 210 }}
+                            />
+                            <Select
+                                size="small"
+                                value={largeHitFilter}
+                                onChange={(value) => setLargeHitFilter(value as HitClassFilter)}
+                                options={[
+                                    { label: "All hit states", value: "all" },
+                                    { label: "Full", value: "full" },
+                                    { label: "Partial", value: "partial" },
+                                    { label: "Empty", value: "empty" },
+                                    { label: "Illegal", value: "illegal" },
+                                    { label: "Ignore", value: "ignore" },
+                                ]}
+                                style={{ minWidth: 160 }}
+                            />
+                            <Select
+                                size="small"
+                                value={largeSort}
+                                onChange={(value) => setLargeSort(value as LargeSortOption)}
+                                options={[
+                                    { label: "Bucket (asc)", value: "bucket_asc" },
+                                    { label: "Bucket (desc)", value: "bucket_desc" },
+                                    { label: "Hits (desc)", value: "hits_desc" },
+                                    { label: "Hits (asc)", value: "hits_asc" },
+                                    { label: "Hit % (desc)", value: "ratio_desc" },
+                                    { label: "Hit % (asc)", value: "ratio_asc" },
+                                ]}
+                                style={{ minWidth: 150 }}
+                            />
+                            <Typography.Text style={{ color: colors.desaturatedtxt.value }}>
+                                Showing {largeDataSource.length.toLocaleString()} of {model.rowCount.toLocaleString()} rows
+                            </Typography.Text>
+                        </Space>
+                    </ConfigProvider>
                 ) : null;
 
                 if (isLargeMode) {

--- a/viewer/src/features/Dashboard/lib/coveragegrid.tsx
+++ b/viewer/src/features/Dashboard/lib/coveragegrid.tsx
@@ -106,6 +106,46 @@ type AxisSortState = {
     mode: AxisSortMode;
 };
 
+const largeModeControlsThemeCache = new Map<string, object>();
+
+function getLargeModeControlsTheme(colors: ThemeType["theme"]["colors"]) {
+    const cacheKey = [
+        colors.primarytxt.value,
+        colors.desaturatedtxt.value,
+        colors.tertiarybg.value,
+        colors.highlightbg.value,
+        colors.lowlightbg.value,
+    ].join("|");
+    const cachedTheme = largeModeControlsThemeCache.get(cacheKey);
+    if (cachedTheme) {
+        return cachedTheme;
+    }
+
+    const nextTheme = {
+        token: {
+            colorText: colors.primarytxt.value,
+            colorTextPlaceholder: colors.desaturatedtxt.value,
+            colorBgElevated: colors.tertiarybg.value,
+            controlItemBgHover: colors.highlightbg.value,
+            controlItemBgActive: colors.lowlightbg.value,
+            colorBorder: colors.lowlightbg.value,
+        },
+        components: {
+            Select: {
+                colorBgContainer: colors.tertiarybg.value,
+                colorText: colors.primarytxt.value,
+                colorTextPlaceholder: colors.desaturatedtxt.value,
+                colorBorder: colors.lowlightbg.value,
+                optionSelectedBg: colors.lowlightbg.value,
+                optionActiveBg: colors.highlightbg.value,
+                selectorBg: colors.tertiarybg.value,
+            },
+        },
+    };
+    largeModeControlsThemeCache.set(cacheKey, nextTheme);
+    return nextTheme;
+}
+
 export type PointGridProps = {
     node: PointNode;
 };
@@ -804,27 +844,7 @@ export function PointGrid({ node }: PointGridProps) {
 
                 const largeControls = isLargeMode ? (
                     <ConfigProvider
-                        theme={{
-                            token: {
-                                colorText: colors.primarytxt.value,
-                                colorTextPlaceholder: colors.desaturatedtxt.value,
-                                colorBgElevated: colors.tertiarybg.value,
-                                controlItemBgHover: colors.highlightbg.value,
-                                controlItemBgActive: colors.lowlightbg.value,
-                                colorBorder: colors.lowlightbg.value,
-                            },
-                            components: {
-                                Select: {
-                                    colorBgContainer: colors.tertiarybg.value,
-                                    colorText: colors.primarytxt.value,
-                                    colorTextPlaceholder: colors.desaturatedtxt.value,
-                                    colorBorder: colors.lowlightbg.value,
-                                    optionSelectedBg: colors.lowlightbg.value,
-                                    optionActiveBg: colors.highlightbg.value,
-                                    selectorBg: colors.tertiarybg.value,
-                                },
-                            },
-                        }}>
+                        theme={getLargeModeControlsTheme(colors)}>
                         <Space wrap style={{ marginBottom: 10, color: colors.primarytxt.value }}>
                             <Typography.Text
                                 strong

--- a/viewer/src/hooks/useFileLoader.tsx
+++ b/viewer/src/hooks/useFileLoader.tsx
@@ -355,6 +355,8 @@ export function useFileLoader() {
                 payloads.push(await loadPayloadFromArchiveItem(items[i]));
                 setLoadingProgress({ completed: i + 1, total: items.length, phase: "reading" });
             }
+            // Let the UI paint the fully-complete file-read progress before final apply starts.
+            await yieldToBrowser();
 
             setLoadingProgress({
                 completed: items.length,


### PR DESCRIPTION
Show collapsible coverage info at the top-level node context (including single-record root), fix root donut rendering, and align large dataset warning/controls with dashboard dark theme tokens.