### PR TITLE
[Patch] Add version accessibility via bucket.version and CLI --version flag

### DIFF
--- a/bin/zsh/.zshrc
+++ b/bin/zsh/.zshrc
@@ -19,6 +19,7 @@ if [ ! -d ".venv" ] || [ ! -f "uv.lock" ]; then
     uv lock
     uv sync --extra dev
 fi
+uv pip install -e . --quiet
 
 # Ensure web environment is installed
 if npm -v >& /dev/null; then

--- a/bucket/__init__.py
+++ b/bucket/__init__.py
@@ -1,11 +1,21 @@
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2023-2024 Vypercore. All Rights Reserved
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _version
 
 from . import rw
 from .axisutils import AxisUtils
 from .context import CoverageContext
 from .covergroup import Covergroup
-from .covertop import Covertop
 from .coverpoint import Coverpoint
+from .covertop import Covertop
+
+try:
+    __version__ = _version("bucket")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
+version = __version__
 
 assert all((CoverageContext, Covergroup, Coverpoint, Covertop, AxisUtils, rw))

--- a/bucket/__main__.py
+++ b/bucket/__main__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: MIT
-# Copyright (c) 2023-2025 Noodle-Bytes. All Rights Reserved
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
 
 from pathlib import Path
 from typing import Iterable
@@ -12,6 +12,7 @@ from .rw.common import MergeReadout, Readout
 
 @click.group()
 @click.pass_context
+@click.version_option(package_name="bucket")
 @click.option(
     "--web-path",
     help="Path to the web viewer",


### PR DESCRIPTION
This pull request updates the `bucket` package with improved version handling and updates to copyright years. The most notable change is the addition of dynamic version retrieval using `importlib.metadata`, which ensures the package version is set automatically. Additionally, the CLI now includes a `--version` option, and copyright statements have been updated.

**Version handling and CLI improvements:**

* Added dynamic version retrieval in `bucket/__init__.py` using `importlib.metadata`, setting `__version__` and `version` variables.
* Added a `--version` option to the CLI using `click.version_option` in `bucket/__main__.py`.

**Copyright updates:**

* Updated copyright years to 2026 in both `bucket/__init__.py` and `bucket/__main__.py`. [[1]](diffhunk://#diff-9ae42641e2b903e9b5d7d285ad1ad1718bfc99734e3adb137c2404a40ad5891fL2-R19) [[2]](diffhunk://#diff-c5ea9faa9c7e90651b26db99d0b22cd7c665c3843c9e9b28f43104eafc505077L2-R2)