### PR TITLE
[Patch] Fix ruff-format formatting after pre-commit auto-fixes

### DIFF
--- a/bucket/rw/archive.py
+++ b/bucket/rw/archive.py
@@ -4,6 +4,7 @@
 import csv
 import tarfile
 import tempfile
+import warnings
 from pathlib import Path
 from typing import Iterable, NamedTuple, overload
 
@@ -20,8 +21,22 @@ from .common import (
     Reader,
     Readout,
     Writer,
+    _get_bucket_version,
     point_tuple_from_row,
 )
+
+
+def _parse_version(v: str) -> tuple[int, ...]:
+    """Parse a version string into a tuple of ints for comparison."""
+    parts = []
+    for p in v.split(".")[:3]:
+        try:
+            parts.append(int(p))
+        except ValueError:
+            parts.append(0)
+    while len(parts) < 3:
+        parts.append(0)
+    return tuple(parts)
 
 
 class ArchiveDefinitionTuple(NamedTuple):
@@ -47,6 +62,7 @@ class ArchiveRecordTuple(NamedTuple):
     bucket_hit_end: int
     source: str  # Stored as "" in CSV, always a string
     source_key: str  # Stored as "" in CSV, always a string
+    bucket_version: str = ""  # Version of bucket that wrote this record
 
 
 DEFINITION_PATH = "definition"
@@ -102,16 +118,21 @@ def _read(
         lines = f.readlines(byte_end - byte_offset - 1)[line_offset:line_end]
 
         for row in csv.reader(lines, quoting=csv.QUOTE_NONNUMERIC):
-            # For record rows (8 fields), keep empty strings as empty strings for source/source_key (indices 6, 7)
+            # For record rows (8 or 9 fields), keep empty strings as empty strings
+            # for source/source_key/bucket_version (indices 6, 7, 8).
             # CSV doesn't support None, so we store "" for empty values
             # For all other rows, convert empty strings to None
-            is_record_row = len(row) == 8  # ArchiveRecordTuple has 8 fields
+            is_record_row = len(row) in (8, 9)  # ArchiveRecordTuple has 8 or 9 fields
             processed_row = []
             for idx, x in enumerate(row):
                 if x == "":
-                    # Keep empty strings as empty strings for source/source_key in record rows
+                    # Keep empty strings for source, source_key, bucket_version in record rows
                     # Convert to None for other fields/rows
-                    if is_record_row and idx in (6, 7):  # source and source_key indices
+                    if is_record_row and idx in (
+                        6,
+                        7,
+                        8,
+                    ):  # source, source_key, bucket_version
                         processed_row.append("")
                     else:
                         processed_row.append(None)
@@ -146,6 +167,29 @@ class ArchiveReadout(Readout):
         )
         self.definition = ArchiveDefinitionTuple(*definition_row)
 
+        file_version = self.record.bucket_version or ""
+        if file_version:
+            installed = _get_bucket_version()
+            if installed != "unknown":
+                fv = _parse_version(file_version)
+                iv = _parse_version(installed)
+                if fv > iv:
+                    warnings.warn(
+                        f"Coverage file was generated with bucket v{file_version}, which is "
+                        f"newer than the installed version (v{installed}). "
+                        "Some data may not be read correctly.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                elif fv < iv:
+                    warnings.warn(
+                        f"Coverage file was generated with an older version of bucket "
+                        f"(v{file_version}); installed version is v{installed}. "
+                        "The reader is broadly backwards compatible.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+
     def get_def_sha(self) -> str:
         return self.definition.def_sha
 
@@ -157,6 +201,9 @@ class ArchiveReadout(Readout):
 
     def get_source_key(self) -> str:
         return self.record.source_key
+
+    def get_bucket_version(self) -> str:
+        return self.record.bucket_version or ""
 
     def iter_points(
         self, start: int = 0, end: int | None = None, depth: int = 0
@@ -325,6 +372,7 @@ class ArchiveWriter(Writer):
             # source and source_key are always strings (empty string if not set)
             source = readout.get_source()
             source_key = readout.get_source_key()
+            bucket_version = readout.get_bucket_version()
             record_offset, _ = _write(
                 work_path / RECORD_PATH,
                 [
@@ -337,6 +385,7 @@ class ArchiveWriter(Writer):
                         bucket_hit_end,
                         source,
                         source_key,
+                        bucket_version,
                     )
                 ],
             )

--- a/bucket/rw/common.py
+++ b/bucket/rw/common.py
@@ -3,10 +3,20 @@
 
 import json
 from datetime import datetime
+from importlib.metadata import PackageNotFoundError as _PKGNotFound
+from importlib.metadata import version as _pkg_version
 from typing import Any, Iterable, NamedTuple, Protocol
 
 from ..common.chain import Link
 from ..link import CovDef, CovRun
+
+
+def _get_bucket_version() -> str:
+    try:
+        return _pkg_version("bucket")
+    except _PKGNotFound:
+        return "unknown"
+
 
 ###############################################################################
 # Coverage information in tuple form, which is used to interface between
@@ -221,6 +231,7 @@ class Readout(Protocol):
     def get_rec_sha(self) -> str: ...
     def get_source(self) -> str: ...
     def get_source_key(self) -> str: ...
+    def get_bucket_version(self) -> str: ...
     def iter_points(
         self, start: int = 0, end: int | None = None, depth: int = 0
     ) -> Iterable[PointTuple]: ...
@@ -623,6 +634,7 @@ class PuppetReadout(Readout):
         self.rec_sha = None
         self._source: str = ""
         self._source_key: str = ""
+        self.bucket_version: str = ""
 
     def get_def_sha(self) -> str:
         if self.def_sha is None:
@@ -655,6 +667,9 @@ class PuppetReadout(Readout):
 
     def get_source_key(self) -> str:
         return self._source_key
+
+    def get_bucket_version(self) -> str:
+        return self.bucket_version
 
     def iter_points(
         self, start: int = 0, end: int | None = None, depth: int = 0
@@ -703,6 +718,7 @@ class MergeReadout(Readout):
         self.master = master
         self.source = f"Merged_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
         self.source_key = ""
+        self._bucket_version = _get_bucket_version()
 
         self.bucket_hits: list[int] = []
         for bucket_hit in master.iter_bucket_hits():
@@ -730,6 +746,9 @@ class MergeReadout(Readout):
 
     def get_source_key(self) -> str:
         return self.source_key
+
+    def get_bucket_version(self) -> str:
+        return self._bucket_version
 
     def iter_points(
         self, start: int = 0, end: int | None = None, depth: int = 0

--- a/bucket/rw/point.py
+++ b/bucket/rw/point.py
@@ -15,6 +15,7 @@ from .common import (
     PointTuple,
     PuppetReadout,
     Reader,
+    _get_bucket_version,
 )
 
 
@@ -40,6 +41,7 @@ class PointReader(Reader):
         chain = point._chain_def()
         readout.def_sha = chain.end.sha.hexdigest()
         readout.rec_sha = self._rec_sha
+        readout.bucket_version = _get_bucket_version()
 
         # Get source and source_key: PointReader params take precedence, then Covertop attributes, then empty string
         # Both PointReader and Covertop store as strings (empty string if not set)

--- a/example/cats.py
+++ b/example/cats.py
@@ -70,7 +70,28 @@ class CatStats(Coverpoint):
 
     # No name provided to demonstrate that class name will be used
     DESCRIPTION = "Some basic cat stats"
-    MOTIVATION = "Track the grand council of kitties and their daily mischief levels"
+    MOTIVATION = (
+        "Cats are the primary agents of domestic entropy and any simulation that omits "
+        "comprehensive felinometric coverage risks systemic under-sampling of the mischief "
+        "distribution. "
+        "The name axis is critical because named cats exhibit statistically higher "
+        "manipulation coefficients than unnamed strays: Clive alone accounts for 34% of "
+        "all unexplained gravity reversals in the test environment, while Derek is "
+        "responsible for the majority of phantom 3am wall-staring incidents that have "
+        "previously gone unmodelled. "
+        "Age is non-negotiable: a kitten at age 0 operates in pure chaos mode with no "
+        "concept of consequence, whereas a 17-year-old senior cat has refined its evil "
+        "to a surgical precision that demands elevated hit targets. "
+        "The evil_thoughts axis ties directly to downstream stimulus generation — a cat "
+        "sitting in the 'high (normal)' band will trigger the adversarial packet injector, "
+        "the cupboard-door rattler, and the 3am yowl subsystem simultaneously, creating "
+        "corner-case interactions that are invisible unless all three axes are crossed "
+        "at their extremes. "
+        "Omitting this coverpoint from any regression sweep has historically correlated "
+        "with a 200% increase in escaped bugs, three mysterious power outages, and one "
+        "occasion where the entire regression farm was found rearranged into a perfect "
+        "circle around an empty bowl."
+    )
     TIER = 1
     TAGS = ["basic", "stats"]
 

--- a/viewer/src/features/Dashboard/index.tsx
+++ b/viewer/src/features/Dashboard/index.tsx
@@ -21,6 +21,7 @@ import {
     Switch,
     Table,
     Typography,
+    Alert,
 } from "antd";
 import {
     CaretDownOutlined,
@@ -36,6 +37,7 @@ import {
     ReloadOutlined,
     SettingOutlined,
     TableOutlined,
+    WarningOutlined,
 } from "@ant-design/icons";
 import Tree, { TreeKey, TreeNode } from "./lib/tree";
 import Sider, { MAX_SIDEBAR_WIDTH, MIN_SIDEBAR_WIDTH } from "./components/Sider";
@@ -59,6 +61,7 @@ import { hexToRgba } from "@/utils/colors";
 import { buildBucketAntModalTheme } from "@/utils/bucketAntModalTheme";
 import type { CoverageRecord, CoverageSourceRef, ExportFormat } from "@/types/coverageSession";
 import { getDefaultExportFileName } from "@/services/exportSaver";
+import { checkVersionCompat } from "@/utils/versionCompat";
 
 declare const __APP_VERSION__: string;
 
@@ -80,6 +83,7 @@ type RootCoverageInfo = {
     source: string | null;
     defSha: string | null;
     recSha: string | null;
+    bucketVersion: string | null;
 };
 
 type TopLevelCoverageCounts = {
@@ -166,6 +170,7 @@ function getTopLevelCoverageInfo(
         source: getReadoutSource(readout),
         defSha: getReadoutValue(readout, "get_def_sha"),
         recSha: getReadoutValue(readout, "get_rec_sha"),
+        bucketVersion: readout.get_bucket_version?.() || null,
     };
 }
 
@@ -225,13 +230,40 @@ function CoverageInfoField({
 
 function TopLevelCoverageInfoPanel({ info }: { info: RootCoverageInfo }) {
     const [isCollapsed, setIsCollapsed] = useState(false);
+    const compat = checkVersionCompat(info.bucketVersion, __APP_VERSION__);
 
     return (
         <Theme.Consumer>
             {({ theme }) => {
                 const colors = theme.theme.colors;
+                const versionNotice = compat.status === "file_newer" ? (
+                    <Alert
+                        type="warning"
+                        icon={<WarningOutlined />}
+                        showIcon
+                        style={{ margin: "0 8px 6px", fontSize: 12 }}
+                        message={`This coverage file was generated with bucket v${compat.fileVersion}, which is newer than this viewer (v${compat.viewerVersion}). Some information may not display correctly.`}
+                    />
+                ) : compat.status === "file_older" ? (
+                    <Alert
+                        type="info"
+                        showIcon
+                        style={{ margin: "0 8px 6px", fontSize: 12 }}
+                        message={`This coverage file was generated with an older version of bucket (v${compat.fileVersion}). The viewer is broadly backwards compatible.`}
+                    />
+                ) : compat.status === "unknown" ? (
+                    <Alert
+                        type="warning"
+                        icon={<WarningOutlined />}
+                        showIcon
+                        style={{ margin: "0 8px 6px", fontSize: 12 }}
+                        message="This coverage file was generated with a version of bucket that did not embed a version number. It is likely an older file — some compatibility issues may be possible, though the viewer is broadly backwards compatible."
+                    />
+                ) : null;
                 return (
-                    <section
+                    <>
+                        {versionNotice}
+                        <section
                         style={{
                             margin: "6px 10px 8px",
                             border: `1px solid ${colors.lowlightbg.value}`,
@@ -294,9 +326,15 @@ function TopLevelCoverageInfoPanel({ info }: { info: RootCoverageInfo }) {
                                     mono
                                     colors={colors}
                                 />
+                                <CoverageInfoField
+                                    label="Bucket Version"
+                                    value={info.bucketVersion}
+                                    colors={colors}
+                                />
                             </div>
                         )}
                     </section>
+                    </>
                 );
             }}
         </Theme.Consumer>

--- a/viewer/src/features/Dashboard/lib/readers.ts
+++ b/viewer/src/features/Dashboard/lib/readers.ts
@@ -46,6 +46,9 @@ export class JSONReadout implements Readout {
     get_source_key(): string | null {
         return this.record.source_key ?? null;
     }
+    get_bucket_version(): string {
+        return "";
+    }
     private *iter_def_table<T extends Record<string, unknown>>(table: string, start: number=0, end: number | null=null): Generator<T> {
         const keys = this.tables[table];
         const tableDef = this.definition[table];
@@ -168,6 +171,7 @@ type ArchiveRecord = {
     bucket_hit_end: number;
     source: string | null;  // Stored as "" in CSV, converted to null when reading
     source_key: string | null;  // Stored as "" in CSV, converted to null when reading
+    bucket_version: string;  // Version of bucket that wrote this record ("" if unknown)
 };
 
 type ArchiveTableMap = Record<ArchiveTableName, ArchiveTable>;
@@ -257,6 +261,10 @@ export class ArchiveReadout implements Readout {
 
     get_source_key(): string | null {
         return this.record.source_key;
+    }
+
+    get_bucket_version(): string {
+        return this.record.bucket_version;
     }
 
     *iter_points(
@@ -495,6 +503,7 @@ function toArchiveRecord(row: (string | number)[]): ArchiveRecord {
         // Convert empty strings to null for source/source_key (CSV stores "" but we use null internally)
         source: source === "" ? null : toString(source),
         source_key: source_key === "" ? null : toString(source_key),
+        bucket_version: row.length > 8 ? toString(row[8]) : "",
     };
 }
 
@@ -616,6 +625,7 @@ function parseCsvTable(data: Uint8Array): { rows: (string | number)[][]; offsets
     const rows: (string | number)[][] = [];
     const offsets: number[] = [];
     const length = data.length;
+    const decoder = new TextDecoder();
     let idx = 0;
 
     while (idx < length) {
@@ -626,7 +636,7 @@ function parseCsvTable(data: Uint8Array): { rows: (string | number)[][]; offsets
 
         offsets.push(idx);
         const row: (string | number)[] = [];
-        let current = "";
+        let currentBytes: number[] = [];
         let inQuotes = false;
 
         while (idx < length) {
@@ -634,7 +644,7 @@ function parseCsvTable(data: Uint8Array): { rows: (string | number)[][]; offsets
             if (inQuotes) {
                 if (byte === 34) {
                     if (data[idx + 1] === 34) {
-                        current += '"';
+                        currentBytes.push(34);
                         idx += 2;
                         continue;
                     }
@@ -642,7 +652,7 @@ function parseCsvTable(data: Uint8Array): { rows: (string | number)[][]; offsets
                     idx += 1;
                     continue;
                 }
-                current += String.fromCharCode(byte);
+                currentBytes.push(byte);
                 idx += 1;
                 continue;
             }
@@ -654,8 +664,8 @@ function parseCsvTable(data: Uint8Array): { rows: (string | number)[][]; offsets
             }
 
             if (byte === 44) {
-                row.push(parseCsvValue(current));
-                current = "";
+                row.push(parseCsvValue(decoder.decode(new Uint8Array(currentBytes))));
+                currentBytes = [];
                 idx += 1;
                 continue;
             }
@@ -670,11 +680,11 @@ function parseCsvTable(data: Uint8Array): { rows: (string | number)[][]; offsets
                 break;
             }
 
-            current += String.fromCharCode(byte);
+            currentBytes.push(byte);
             idx += 1;
         }
 
-        row.push(parseCsvValue(current));
+        row.push(parseCsvValue(decoder.decode(new Uint8Array(currentBytes))));
         rows.push(row);
     }
 

--- a/viewer/src/services/readoutUtils.ts
+++ b/viewer/src/services/readoutUtils.ts
@@ -8,6 +8,7 @@ type MaterializedReadoutData = {
     recSha: string;
     source: string | null;
     sourceKey: string | null;
+    bucketVersion: string;
     points: PointTuple[];
     bucketGoals: BucketGoalTuple[];
     axes: AxisTuple[];
@@ -70,6 +71,10 @@ export class InMemoryReadout implements Readout {
 
     get_source_key(): string | null {
         return this.data.sourceKey;
+    }
+
+    get_bucket_version(): string {
+        return this.data.bucketVersion;
     }
 
     *iter_points(
@@ -142,6 +147,7 @@ export function materializeReadout(readout: Readout): MaterializedReadoutData {
         recSha: readout.get_rec_sha(),
         source: readout.get_source(),
         sourceKey: readout.get_source_key(),
+        bucketVersion: readout.get_bucket_version(),
         points: Array.from(readout.iter_points()).map(clonePointTuple),
         bucketGoals: Array.from(readout.iter_bucket_goals(0, null)).map(cloneBucketGoalTuple),
         axes: Array.from(readout.iter_axes(0, null)).map(cloneAxisTuple),
@@ -273,6 +279,7 @@ export function mergeReadoutsStrict(readouts: Readout[]): Readout {
         recSha: master.recSha,
         source: getMergedSourceName(),
         sourceKey: "",
+        bucketVersion: master.bucketVersion,
         points: master.points,
         bucketGoals: master.bucketGoals,
         axes: master.axes,

--- a/viewer/src/types/coverage.ts
+++ b/viewer/src/types/coverage.ts
@@ -67,6 +67,7 @@ type Readout = {
     get_rec_sha: () => string;
     get_source: () => string | null;
     get_source_key: () => string | null;
+    get_bucket_version: () => string;
     iter_points: (
         start?: number,
         end?: number | null,

--- a/viewer/src/utils/versionCompat.ts
+++ b/viewer/src/utils/versionCompat.ts
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+ */
+
+/**
+ * Compare two semver-like version strings (major.minor.patch).
+ * Returns -1 if a < b, 0 if equal, 1 if a > b.
+ * Non-numeric or missing parts are treated as 0.
+ */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 {
+    const parse = (v: string) =>
+        v
+            .split(".")
+            .slice(0, 3)
+            .map((p) => parseInt(p, 10) || 0);
+
+    const [aMaj, aMin, aPat] = parse(a);
+    const [bMaj, bMin, bPat] = parse(b);
+
+    if (aMaj !== bMaj) return aMaj > bMaj ? 1 : -1;
+    if (aMin !== bMin) return aMin > bMin ? 1 : -1;
+    if (aPat !== bPat) return aPat > bPat ? 1 : -1;
+    return 0;
+}
+
+export type VersionCompatResult =
+    | { status: "unknown" }
+    | { status: "match" }
+    | { status: "file_older"; fileVersion: string; viewerVersion: string }
+    | { status: "file_newer"; fileVersion: string; viewerVersion: string };
+
+/**
+ * Determine compatibility between the version embedded in a coverage file
+ * and the version of the viewer.
+ */
+export function checkVersionCompat(
+    fileVersion: string | null,
+    viewerVersion: string,
+): VersionCompatResult {
+    if (!fileVersion) {
+        return { status: "unknown" };
+    }
+    const cmp = compareVersions(fileVersion, viewerVersion);
+    if (cmp === 0) {
+        return { status: "match" };
+    }
+    if (cmp < 0) {
+        return { status: "file_older", fileVersion, viewerVersion };
+    }
+    return { status: "file_newer", fileVersion, viewerVersion };
+}


### PR DESCRIPTION
This pull request introduces version tracking and compatibility checks for coverage files generated by the "bucket" tool. The changes ensure that every coverage record now includes the version of "bucket" that created it, and both the backend and frontend warn users if there is a version mismatch between the file and the viewer. Additionally, the frontend displays the file's bucket version and provides user-friendly alerts about compatibility.

Key changes include:

**Backend: Version Tracking and Compatibility Warnings**
* Added `bucket_version` as a new field to coverage records (`ArchiveRecordTuple`), and updated all relevant read/write logic to handle this field. (`bucket/rw/archive.py`, `bucket/rw/common.py`, [[1]](diffhunk://#diff-4c9af9c0797c2b5ca8c398783b0afab7f38f79ec9d73efb9a161d83e43b7558eR65) [[2]](diffhunk://#diff-4c9af9c0797c2b5ca8c398783b0afab7f38f79ec9d73efb9a161d83e43b7558eL105-R135) [[3]](diffhunk://#diff-4c9af9c0797c2b5ca8c398783b0afab7f38f79ec9d73efb9a161d83e43b7558eR375) [[4]](diffhunk://#diff-4c9af9c0797c2b5ca8c398783b0afab7f38f79ec9d73efb9a161d83e43b7558eR388) [[5]](diffhunk://#diff-2cdec18af8ff4c54e830726113b2f9eb6f565d88629594bef7434e7f300cb734R637) [[6]](diffhunk://#diff-2cdec18af8ff4c54e830726113b2f9eb6f565d88629594bef7434e7f300cb734R671-R673) [[7]](diffhunk://#diff-2cdec18af8ff4c54e830726113b2f9eb6f565d88629594bef7434e7f300cb734R721)
* Implemented `_get_bucket_version()` to retrieve the installed bucket package version, and embedded this version into new coverage files. (`bucket/rw/common.py`, [bucket/rw/common.pyR6-R20](diffhunk://#diff-2cdec18af8ff4c54e830726113b2f9eb6f565d88629594bef7434e7f300cb734R6-R20))
* On reading a coverage file, the backend now compares the file's bucket version to the installed version and emits warnings if the file is newer or older, improving user awareness of potential compatibility issues. (`bucket/rw/archive.py`, [bucket/rw/archive.pyR170-R192](diffhunk://#diff-4c9af9c0797c2b5ca8c398783b0afab7f38f79ec9d73efb9a161d83e43b7558eR170-R192))

**Frontend: Display and Compatibility Alerts**
* Updated the frontend's record and readout types to include `bucket_version`, and display this value in the coverage info panel. (`viewer/src/features/Dashboard/index.tsx`, `viewer/src/features/Dashboard/lib/readers.ts`, [[1]](diffhunk://#diff-b801c4254e94bc12538f6c99b6e24ce141d11a02f892e3c3bd445c5b10306077R86) [[2]](diffhunk://#diff-b801c4254e94bc12538f6c99b6e24ce141d11a02f892e3c3bd445c5b10306077R329-R337) [[3]](diffhunk://#diff-4e5de118b86947d855c74955fb52cf0b1436ad517f4146e1f07590b743ed80bdR174) [[4]](diffhunk://#diff-4e5de118b86947d855c74955fb52cf0b1436ad517f4146e1f07590b743ed80bdR506)
* Added logic to check for version compatibility between the coverage file and the viewer, and display prominent alerts if the file is newer, older, or missing version info. (`viewer/src/features/Dashboard/index.tsx`, [viewer/src/features/Dashboard/index.tsxR233-R265](diffhunk://#diff-b801c4254e94bc12538f6c99b6e24ce141d11a02f892e3c3bd445c5b10306077R233-R265))
* Ensured all readout implementations (including JSON and archive) provide a `get_bucket_version()` method. (`viewer/src/features/Dashboard/lib/readers.ts`, [[1]](diffhunk://#diff-4e5de118b86947d855c74955fb52cf0b1436ad517f4146e1f07590b743ed80bdR49-R51) [[2]](diffhunk://#diff-4e5de118b86947d855c74955fb52cf0b1436ad517f4146e1f07590b743ed80bdR266-R269)

**Other Improvements**
* Expanded the motivation comment for the `CatStats` example coverpoint to test very large strings. (`example/cats.py`, [example/cats.pyL73-R94](diffhunk://#diff-497f0e4d107ea902f8b1336d11a07fd884966ad3deff0b523d33fe8295593c5cL73-R94))

These changes collectively improve traceability, compatibility, and user experience when working with coverage files across different versions of the "bucket" tool.