### PR TITLE
[Patch] Dashboard summary, Coverage Info, and donut layout

### DIFF
--- a/viewer/src/features/Dashboard/index.tsx
+++ b/viewer/src/features/Dashboard/index.tsx
@@ -56,6 +56,7 @@ import {
     useState,
 } from "react";
 import { BreadcrumbItemType } from "antd/lib/breadcrumb/Breadcrumb";
+import { BUCKET_DONUT_LAYOUT_EVENT } from "./lib/coveragedonut-constants";
 import { PointGrid, PointSummaryGrid } from "./lib/coveragegrid";
 import { PointPivotView } from "./lib/pivottable";
 import { CoverageDonut } from "./lib/coveragedonut";
@@ -323,19 +324,25 @@ function TopLevelCoverageInfoPanel({
             return;
         }
         let cancelled = false;
-        const signalResize = () => {
-            requestAnimationFrame(() => {
-                requestAnimationFrame(() => {
+        let rafOuter = 0;
+        let rafInner = 0;
+        const bumpDonutLayout = () => {
+            cancelAnimationFrame(rafOuter);
+            cancelAnimationFrame(rafInner);
+            rafOuter = requestAnimationFrame(() => {
+                rafInner = requestAnimationFrame(() => {
                     if (!cancelled) {
-                        window.dispatchEvent(new Event("resize"));
+                        window.dispatchEvent(new CustomEvent(BUCKET_DONUT_LAYOUT_EVENT));
                     }
                 });
             });
         };
-        signalResize();
-        const t = window.setTimeout(signalResize, 50);
+        bumpDonutLayout();
+        const t = window.setTimeout(bumpDonutLayout, 50);
         return () => {
             cancelled = true;
+            cancelAnimationFrame(rafOuter);
+            cancelAnimationFrame(rafInner);
             window.clearTimeout(t);
         };
     }, [isCollapsed, compat.status, versionAlertDismissed]);

--- a/viewer/src/features/Dashboard/index.tsx
+++ b/viewer/src/features/Dashboard/index.tsx
@@ -322,8 +322,22 @@ function TopLevelCoverageInfoPanel({
         if (typeof window === "undefined") {
             return;
         }
-        // Donut view listens for resize to recompute available space.
-        window.dispatchEvent(new Event("resize"));
+        let cancelled = false;
+        const signalResize = () => {
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    if (!cancelled) {
+                        window.dispatchEvent(new Event("resize"));
+                    }
+                });
+            });
+        };
+        signalResize();
+        const t = window.setTimeout(signalResize, 50);
+        return () => {
+            cancelled = true;
+            window.clearTimeout(t);
+        };
     }, [isCollapsed, compat.status, versionAlertDismissed]);
 
     return (
@@ -469,10 +483,30 @@ function withTopLevelInfoPanel({
     }
 
     return (
-        <>
-            <TopLevelCoverageInfoPanel info={info} treeSelectionKey={treeSelectionKey} />
-            {content}
-        </>
+        <div
+            style={{
+                display: "flex",
+                flexDirection: "column",
+                flex: "1 1 auto",
+                minHeight: 0,
+                width: "100%",
+            }}>
+            <div style={{ flexShrink: 0, width: "100%" }}>
+                <TopLevelCoverageInfoPanel info={info} treeSelectionKey={treeSelectionKey} />
+            </div>
+            <div
+                style={{
+                    flex: "1 1 auto",
+                    minHeight: 0,
+                    overflow: "auto",
+                    width: "100%",
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "stretch",
+                }}>
+                {content}
+            </div>
+        </div>
     );
 }
 

--- a/viewer/src/features/Dashboard/index.tsx
+++ b/viewer/src/features/Dashboard/index.tsx
@@ -82,6 +82,8 @@ type RootCoverageInfo = {
     name: string;
     coverpoints: number;
     covergroups: number;
+    hitsVsTargetText: string;
+    overallCoverageText: string;
     source: string | null;
     defSha: string | null;
     recSha: string | null;
@@ -164,11 +166,16 @@ function getTopLevelCoverageInfo(
     counts: TopLevelCoverageCounts,
 ): RootCoverageInfo {
     const readout = node.data.readout as Readout;
+    const target = Number(node.data.point?.target ?? 0);
+    const hits = Number(node.data.point_hit?.hits ?? 0);
+    const overallCoverage = target > 0 ? hits / target : 0;
 
     return {
         name: node.data.point?.name ?? String(node.title),
         coverpoints: counts.coverpoints,
         covergroups: counts.covergroups,
+        hitsVsTargetText: `${hits.toLocaleString()} / ${target.toLocaleString()}`,
+        overallCoverageText: `${(overallCoverage * 100).toFixed(1)}%`,
         source: getReadoutSource(readout),
         defSha: getReadoutValue(readout, "get_def_sha"),
         recSha: getReadoutValue(readout, "get_rec_sha"),
@@ -311,6 +318,14 @@ function TopLevelCoverageInfoPanel({
         setVersionAlertDismissed(true);
     }, []);
 
+    useEffect(() => {
+        if (typeof window === "undefined") {
+            return;
+        }
+        // Donut view listens for resize to recompute available space.
+        window.dispatchEvent(new Event("resize"));
+    }, [isCollapsed, compat.status, versionAlertDismissed]);
+
     return (
         <Theme.Consumer>
             {({ theme }) => {
@@ -392,6 +407,16 @@ function TopLevelCoverageInfoPanel({
                                 <CoverageInfoField
                                     label="Covergroups"
                                     value={info.covergroups.toLocaleString()}
+                                    colors={colors}
+                                />
+                                <CoverageInfoField
+                                    label="Overall Coverage"
+                                    value={info.overallCoverageText}
+                                    colors={colors}
+                                />
+                                <CoverageInfoField
+                                    label="Hits / Target"
+                                    value={info.hitsVsTargetText}
                                     colors={colors}
                                 />
                                 <CoverageInfoField

--- a/viewer/src/features/Dashboard/lib/coveragedonut-constants.ts
+++ b/viewer/src/features/Dashboard/lib/coveragedonut-constants.ts
@@ -7,6 +7,9 @@
 // Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
 
 // Chart constants for CoverageDonut
+/** Fired when Coverage Info / version banner layout shifts so the donut can remeasure without a global `resize`. */
+export const BUCKET_DONUT_LAYOUT_EVENT = "bucket-donut-layout";
+
 export const CHART_MARGIN = 16; // Increased margin in pixels around the chart
 export const MIN_CENTER_RADIUS = 150; // Minimum center circle radius
 export const MAX_CENTER_RADIUS_RATIO = 0.45; // Maximum center circle as ratio of maxRadius

--- a/viewer/src/features/Dashboard/lib/coveragedonut-utils.ts
+++ b/viewer/src/features/Dashboard/lib/coveragedonut-utils.ts
@@ -98,8 +98,9 @@ function expandBBoxAnnularSector(
 }
 
 /**
- * Centroid of the visible donut (center hub + arc wedges) in group-local coords.
- * Used to translate the chart so asymmetric wedges get even vertical padding in the square SVG.
+ * Bounding-box midpoint of the visible donut (center hub + arc wedges) in group-local coords.
+ * Not a geometric centroid — only the axis-aligned center of the union bbox.
+ * Used to translate the chart so asymmetric wedges get even padding in the square SVG.
  */
 export function computeSunburstVisualMidpoint(
     flatData: SunburstNode[],

--- a/viewer/src/features/Dashboard/lib/coveragedonut-utils.ts
+++ b/viewer/src/features/Dashboard/lib/coveragedonut-utils.ts
@@ -40,6 +40,111 @@ export function polarToCartesian(radius: number, angle: number): { x: number; y:
     };
 }
 
+/** Ring geometry for sunburst arcs (depth ≥ 1). */
+export function calculateRingRadii(
+    depth: number,
+    maxDepth: number,
+    startInnerRadius: number,
+    maxRadius: number,
+): { innerRadius: number; outerRadius: number } | null {
+    if (maxDepth === 0) {
+        return null;
+    }
+    const ringThickness = (maxRadius - startInnerRadius) / maxDepth;
+    const innerRadius = startInnerRadius + ringThickness * (depth - 1);
+    const outerRadius = innerRadius + ringThickness;
+    return { innerRadius, outerRadius };
+}
+
+/** Angles where \(x\) or \(y\) hits extrema on a circle (matches polarToCartesian). */
+const QUADRANT_ANGLES = [0, Math.PI / 2, Math.PI, (3 * Math.PI) / 2];
+
+function expandBBoxPoint(
+    bb: { minX: number; maxX: number; minY: number; maxY: number },
+    x: number,
+    y: number,
+) {
+    bb.minX = Math.min(bb.minX, x);
+    bb.maxX = Math.max(bb.maxX, x);
+    bb.minY = Math.min(bb.minY, y);
+    bb.maxY = Math.max(bb.maxY, y);
+}
+
+function expandBBoxAnnularSector(
+    bb: { minX: number; maxX: number; minY: number; maxY: number },
+    innerRadius: number,
+    outerRadius: number,
+    startAngle: number,
+    endAngle: number,
+) {
+    const lo = Math.min(startAngle, endAngle);
+    const hi = Math.max(startAngle, endAngle);
+
+    const tryAngle = (theta: number) => {
+        if (theta < lo || theta > hi) {
+            return;
+        }
+        const inner = polarToCartesian(innerRadius, theta);
+        const outer = polarToCartesian(outerRadius, theta);
+        expandBBoxPoint(bb, inner.x, inner.y);
+        expandBBoxPoint(bb, outer.x, outer.y);
+    };
+
+    tryAngle(lo);
+    tryAngle(hi);
+    for (const a of QUADRANT_ANGLES) {
+        tryAngle(a);
+    }
+}
+
+/**
+ * Centroid of the visible donut (center hub + arc wedges) in group-local coords.
+ * Used to translate the chart so asymmetric wedges get even vertical padding in the square SVG.
+ */
+export function computeSunburstVisualMidpoint(
+    flatData: SunburstNode[],
+    maxDepth: number,
+    startInnerRadius: number,
+    maxRadius: number,
+    centerCircleRadius: number,
+): { midX: number; midY: number } {
+    const bb = {
+        minX: Infinity,
+        maxX: -Infinity,
+        minY: Infinity,
+        maxY: -Infinity,
+    };
+
+    expandBBoxPoint(bb, -centerCircleRadius, -centerCircleRadius);
+    expandBBoxPoint(bb, centerCircleRadius, centerCircleRadius);
+
+    for (const n of flatData) {
+        if (n.depth <= 0) {
+            continue;
+        }
+        const ring = calculateRingRadii(n.depth, maxDepth, startInnerRadius, maxRadius);
+        if (!ring) {
+            continue;
+        }
+        expandBBoxAnnularSector(bb, ring.innerRadius, ring.outerRadius, n.startAngle, n.endAngle);
+    }
+
+    if (!Number.isFinite(bb.minX)) {
+        return { midX: 0, midY: 0 };
+    }
+
+    const pad = 2;
+    bb.minX -= pad;
+    bb.maxX += pad;
+    bb.minY -= pad;
+    bb.maxY += pad;
+
+    return {
+        midX: (bb.minX + bb.maxX) / 2,
+        midY: (bb.minY + bb.maxY) / 2,
+    };
+}
+
 export function arcPath(
     innerRadius: number,
     outerRadius: number,
@@ -64,8 +169,8 @@ export function arcPath(
 export function buildNode(node: PointNode): HierarchicalData {
     const nodeTitle = String(node.title || '');
     const isCovergroup = Array.isArray(node.children) && node.children.length > 0;
-    const pointTargetValue = Number((node as any)?.data?.point?.target);
-    const pointHitsValue = Number((node as any)?.data?.point_hit?.hits);
+    const pointTargetValue = Number(node.data.point?.target);
+    const pointHitsValue = Number(node.data.point_hit?.hits);
     const hasPointMetrics = Number.isFinite(pointTargetValue) && Number.isFinite(pointHitsValue);
     const nodeData: HierarchicalData = {
         name: nodeTitle,

--- a/viewer/src/features/Dashboard/lib/coveragedonut.tsx
+++ b/viewer/src/features/Dashboard/lib/coveragedonut.tsx
@@ -15,6 +15,8 @@ import {
     buildNode,
     flattenData,
     SunburstNode,
+    calculateRingRadii,
+    computeSunburstVisualMidpoint,
 } from "./coveragedonut-utils";
 import { getCoverageColor } from "@/utils/colors";
 import { CHART_MARGIN } from "./coveragedonut-constants";
@@ -26,14 +28,6 @@ export type CoverageDonutProps = {
     setSelectedTreeKeys?: (keys: TreeKey[]) => void;
 };
 
-function calculateRingRadii(depth: number, maxDepth: number, startInnerRadius: number, maxRadius: number) {
-    if (maxDepth === 0) return null;
-    const ringThickness = (maxRadius - startInnerRadius) / maxDepth;
-    const innerRadius = startInnerRadius + ringThickness * (depth - 1);
-    const outerRadius = innerRadius + ringThickness;
-    return { innerRadius, outerRadius };
-}
-
 function CoverageDonutInner({
     node,
     themeContext,
@@ -42,7 +36,7 @@ function CoverageDonutInner({
     node: PointNode;
     themeContext: {
         theme: ThemeType;
-        setTheme: (theme: any) => void;
+        setTheme: (theme: ThemeType | null) => void;
     };
     setSelectedTreeKeys?: (keys: TreeKey[]) => void;
 }) {
@@ -63,51 +57,113 @@ function CoverageDonutInner({
     });
     useEffect(() => {
         setMounted(true);
-        const updateSize = () => {
-            if (containerRef.current) {
-                const rect = containerRef.current.getBoundingClientRect();
-                const padding = 40;
-                const viewportBottomPadding = 24;
-                const availableViewportHeight = Math.max(
-                    220,
-                    window.innerHeight - rect.top - viewportBottomPadding,
-                );
-                const availableViewportWidth = Math.max(220, rect.width - padding);
-                setContainerSize({
-                    width: availableViewportWidth,
-                    height: Math.max(220, Math.min(rect.height - padding, availableViewportHeight)),
-                });
-            } else {
-                setContainerSize({
-                    width: window.innerWidth * 0.8,
-                    height: window.innerHeight * 0.8,
-                });
-            }
-        };
-        updateSize();
-        const timeout1 = setTimeout(updateSize, 0);
-        const timeout2 = setTimeout(updateSize, 100);
-        const resizeObserver =
-            typeof ResizeObserver !== "undefined" && containerRef.current
-                ? new ResizeObserver(() => updateSize())
-                : null;
-        if (resizeObserver && containerRef.current) {
-            resizeObserver.observe(containerRef.current);
+    }, []);
+
+    useEffect(() => {
+        if (!mounted) {
+            return;
         }
-        window.addEventListener('resize', updateSize);
+
+        const measure = () => {
+            requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                    const el = containerRef.current;
+                    if (!el) {
+                        setContainerSize({
+                            width: window.innerWidth * 0.8,
+                            height: window.innerHeight * 0.8,
+                        });
+                        return;
+                    }
+                    const rect = el.getBoundingClientRect();
+                    const padding = 40;
+                    const viewportBottomPadding = 24;
+                    const availableViewportWidth = Math.max(220, rect.width - padding);
+                    const viewportHeightCap = Math.max(
+                        180,
+                        window.innerHeight - rect.top - viewportBottomPadding - padding,
+                    );
+                    const parentHeightCap =
+                        rect.height > 2 ? Math.max(180, rect.height - padding) : viewportHeightCap;
+                    const heightBudget = Math.max(220, Math.min(viewportHeightCap, parentHeightCap));
+
+                    setContainerSize({
+                        width: availableViewportWidth,
+                        height: heightBudget,
+                    });
+                });
+            });
+        };
+
+        measure();
+        const timeout1 = setTimeout(measure, 0);
+        const timeout2 = setTimeout(measure, 120);
+
+        const resizeObserver =
+            typeof ResizeObserver !== "undefined" ? new ResizeObserver(measure) : null;
+        const el = containerRef.current;
+        if (resizeObserver && el) {
+            resizeObserver.observe(el);
+            if (el.parentElement) {
+                resizeObserver.observe(el.parentElement);
+            }
+        }
+
+        window.addEventListener("resize", measure);
         return () => {
-            window.removeEventListener('resize', updateSize);
+            window.removeEventListener("resize", measure);
             clearTimeout(timeout1);
             clearTimeout(timeout2);
             resizeObserver?.disconnect();
         };
-    }, []);
+    }, [mounted]);
 
     // Build hierarchical data from node
     const hierarchicalData = useMemo(
         () => buildNode(node),
         [node]
     );
+    const flatData = useMemo(() => {
+        return flattenData(hierarchicalData, 0, 0, hierarchicalData.value);
+    }, [hierarchicalData]);
+    const maxDepth = useMemo(() => {
+        return Math.max(...flatData.map(n => n.depth).filter(d => d > 0), 0);
+    }, [flatData]);
+    const dimensions = useMemo(() => {
+        const size = Math.max(180, Math.min(containerSize.width, containerSize.height));
+        const center = size / 2;
+        const centerCircleRadius = Math.max(60, size * 0.18);
+        const maxRadius = center - CHART_MARGIN;
+        const textScaleFactor = 1;
+        return { size, center, centerCircleRadius, maxRadius, textScaleFactor };
+    }, [containerSize]);
+
+    const contentMid = useMemo(() => {
+        const startInner = dimensions.centerCircleRadius + 2;
+        return computeSunburstVisualMidpoint(
+            flatData,
+            maxDepth,
+            startInner,
+            dimensions.maxRadius,
+            dimensions.centerCircleRadius,
+        );
+    }, [
+        flatData,
+        maxDepth,
+        dimensions.centerCircleRadius,
+        dimensions.maxRadius,
+    ]);
+
+    const chartGroupTransform = `translate(${dimensions.center - contentMid.midX},${dimensions.center - contentMid.midY})`;
+    const handleNodeClick = (node: SunburstNode) => {
+        if (node.nodeKey && setSelectedTreeKeys) {
+            setSelectedTreeKeys([node.nodeKey]);
+        }
+    };
+    if (!mounted) {
+        return null;
+    }
+
     if (!hierarchicalData) {
         return (
             <div
@@ -123,28 +179,7 @@ function CoverageDonutInner({
             </div>
         );
     }
-    const flatData = useMemo(() => {
-        return flattenData(hierarchicalData, 0, 0, hierarchicalData.value);
-    }, [hierarchicalData]);
-    const maxDepth = useMemo(() => {
-        return Math.max(...flatData.map(n => n.depth).filter(d => d > 0), 0);
-    }, [flatData]);
-    const dimensions = useMemo(() => {
-        const size = Math.max(180, Math.min(containerSize.width, containerSize.height));
-        const center = size / 2;
-        const centerCircleRadius = Math.max(60, size * 0.18);
-        const maxRadius = center - CHART_MARGIN;
-        const textScaleFactor = 1;
-        return { size, center, centerCircleRadius, maxRadius, textScaleFactor };
-    }, [containerSize]);
-    const handleNodeClick = (node: SunburstNode) => {
-        if (node.nodeKey && setSelectedTreeKeys) {
-            setSelectedTreeKeys([node.nodeKey]);
-        }
-    };
-    if (!mounted) {
-        return null;
-    }
+
     const startInnerRadius = dimensions.centerCircleRadius + 2;
 
     if (isGridMode) {
@@ -177,7 +212,7 @@ function CoverageDonutInner({
                     viewBox={`0 0 ${dimensions.size} ${dimensions.size}`}
                     style={{ display: 'block', margin: '0 auto', overflow: 'visible' }}
                 >
-                    <g transform={`translate(${dimensions.center},${dimensions.center})`}>
+                    <g transform={chartGroupTransform}>
                         {flatData.filter(n => n.depth > 0).map((n, idx) => {
                             const ring = calculateRingRadii(
                                 n.depth,
@@ -221,16 +256,17 @@ function CoverageDonutInner({
         <div
             ref={containerRef}
             style={{
-                width: '100%',
-                height: '100%',
-                minHeight: 220,
+                flex: "1 1 auto",
+                width: "100%",
+                minHeight: 0,
+                height: "100%",
                 padding: 24,
-                display: 'flex',
+                display: "flex",
                 flexDirection: "column",
-                alignItems: 'center',
-                justifyContent: 'center',
-                position: 'relative',
-                boxSizing: 'border-box',
+                alignItems: "center",
+                justifyContent: "center",
+                position: "relative",
+                boxSizing: "border-box",
             }}
         >
             <svg
@@ -239,7 +275,7 @@ function CoverageDonutInner({
                 viewBox={`0 0 ${dimensions.size} ${dimensions.size}`}
                 style={{ display: 'block', margin: '0 auto', overflow: 'visible' }}
             >
-                <g transform={`translate(${dimensions.center},${dimensions.center})`}>
+                <g transform={chartGroupTransform}>
                     {flatData.filter(n => n.depth > 0).map((n, idx) => {
                         const ring = calculateRingRadii(
                             n.depth,

--- a/viewer/src/features/Dashboard/lib/coveragedonut.tsx
+++ b/viewer/src/features/Dashboard/lib/coveragedonut.tsx
@@ -61,16 +61,21 @@ function CoverageDonutInner({
         }
         return { width: 800, height: 600 };
     });
-
     useEffect(() => {
         setMounted(true);
         const updateSize = () => {
             if (containerRef.current) {
                 const rect = containerRef.current.getBoundingClientRect();
                 const padding = 40;
+                const viewportBottomPadding = 24;
+                const availableViewportHeight = Math.max(
+                    220,
+                    window.innerHeight - rect.top - viewportBottomPadding,
+                );
+                const availableViewportWidth = Math.max(220, rect.width - padding);
                 setContainerSize({
-                    width: Math.max(260, rect.width - padding),
-                    height: Math.max(260, rect.height - padding),
+                    width: availableViewportWidth,
+                    height: Math.max(220, Math.min(rect.height - padding, availableViewportHeight)),
                 });
             } else {
                 setContainerSize({
@@ -82,11 +87,19 @@ function CoverageDonutInner({
         updateSize();
         const timeout1 = setTimeout(updateSize, 0);
         const timeout2 = setTimeout(updateSize, 100);
+        const resizeObserver =
+            typeof ResizeObserver !== "undefined" && containerRef.current
+                ? new ResizeObserver(() => updateSize())
+                : null;
+        if (resizeObserver && containerRef.current) {
+            resizeObserver.observe(containerRef.current);
+        }
         window.addEventListener('resize', updateSize);
         return () => {
             window.removeEventListener('resize', updateSize);
             clearTimeout(timeout1);
             clearTimeout(timeout2);
+            resizeObserver?.disconnect();
         };
     }, []);
 
@@ -110,30 +123,14 @@ function CoverageDonutInner({
             </div>
         );
     }
-    // Calculate totals
-    const totals = useMemo(() => {
-        let hits = 0;
-        let target = 0;
-        function walk(node: typeof hierarchicalData) {
-            if (typeof node.target === 'number' && typeof node.hits === 'number') {
-                hits += node.hits;
-                target += node.target;
-            }
-            if (node.children) node.children.forEach(walk);
-        }
-        walk(hierarchicalData);
-        return { hits, target };
-    }, [hierarchicalData]);
-    const overallCoverage = totals.target > 0 ? totals.hits / totals.target : 0;
     const flatData = useMemo(() => {
         return flattenData(hierarchicalData, 0, 0, hierarchicalData.value);
     }, [hierarchicalData]);
     const maxDepth = useMemo(() => {
         return Math.max(...flatData.map(n => n.depth).filter(d => d > 0), 0);
     }, [flatData]);
-    // Chart dimensions (dummy for now)
     const dimensions = useMemo(() => {
-        const size = Math.min(containerSize.width, containerSize.height);
+        const size = Math.max(180, Math.min(containerSize.width, containerSize.height));
         const center = size / 2;
         const centerCircleRadius = Math.max(60, size * 0.18);
         const maxRadius = center - CHART_MARGIN;
@@ -226,10 +223,10 @@ function CoverageDonutInner({
             style={{
                 width: '100%',
                 height: '100%',
-                minHeight: 480,
+                minHeight: 220,
                 padding: 24,
                 display: 'flex',
-                flexDirection: 'column',
+                flexDirection: "column",
                 alignItems: 'center',
                 justifyContent: 'center',
                 position: 'relative',
@@ -299,21 +296,6 @@ function CoverageDonutInner({
                     )}
                 </g>
             </svg>
-            <div
-                style={{
-                    marginTop: 18,
-                    textAlign: 'center',
-                    color: theme.colors.desaturatedtxt.value,
-                    fontSize: 15,
-                    fontWeight: 400,
-                }}
-            >
-                <div>
-                    <b>Overall Coverage:</b> {(overallCoverage * 100).toFixed(1)}%
-                </div>
-                <div>Target: {totals.target.toLocaleString()}</div>
-                <div>Hits: {totals.hits.toLocaleString()}</div>
-            </div>
         </div>
     );
 }

--- a/viewer/src/features/Dashboard/lib/coveragedonut.tsx
+++ b/viewer/src/features/Dashboard/lib/coveragedonut.tsx
@@ -19,7 +19,7 @@ import {
     computeSunburstVisualMidpoint,
 } from "./coveragedonut-utils";
 import { getCoverageColor } from "@/utils/colors";
-import { CHART_MARGIN } from "./coveragedonut-constants";
+import { BUCKET_DONUT_LAYOUT_EVENT, CHART_MARGIN } from "./coveragedonut-constants";
 import { CenterInfo } from "./coveragedonut-centerinfo";
 
 export type CoverageDonutProps = {
@@ -64,9 +64,18 @@ function CoverageDonutInner({
             return;
         }
 
+        let cancelled = false;
+        let rafOuter = 0;
+        let rafInner = 0;
+
         const measure = () => {
-            requestAnimationFrame(() => {
-                requestAnimationFrame(() => {
+            cancelAnimationFrame(rafOuter);
+            cancelAnimationFrame(rafInner);
+            rafOuter = requestAnimationFrame(() => {
+                rafInner = requestAnimationFrame(() => {
+                    if (cancelled) {
+                        return;
+                    }
                     const el = containerRef.current;
                     if (!el) {
                         setContainerSize({
@@ -109,9 +118,16 @@ function CoverageDonutInner({
             }
         }
 
+        const onLayoutBump = () => measure();
+
         window.addEventListener("resize", measure);
+        window.addEventListener(BUCKET_DONUT_LAYOUT_EVENT, onLayoutBump);
         return () => {
+            cancelled = true;
+            cancelAnimationFrame(rafOuter);
+            cancelAnimationFrame(rafInner);
             window.removeEventListener("resize", measure);
+            window.removeEventListener(BUCKET_DONUT_LAYOUT_EVENT, onLayoutBump);
             clearTimeout(timeout1);
             clearTimeout(timeout2);
             resizeObserver?.disconnect();
@@ -162,22 +178,6 @@ function CoverageDonutInner({
     };
     if (!mounted) {
         return null;
-    }
-
-    if (!hierarchicalData) {
-        return (
-            <div
-                style={{
-                    padding: '24px',
-                    display: 'flex',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                    color: theme.colors.desaturatedtxt.value,
-                }}
-            >
-                No coverage data available
-            </div>
-        );
     }
 
     const startInnerRadius = dimensions.centerCircleRadius + 2;

--- a/viewer/src/features/Dashboard/lib/coveragegrid.tsx
+++ b/viewer/src/features/Dashboard/lib/coveragegrid.tsx
@@ -1919,7 +1919,7 @@ export function PointSummaryGrid({ tree, node, setSelectedTreeKeys }: PointSumma
                         }}
                     />
                 );
-                return (
+                const label = (
                     <a
                         style={{
                             paddingLeft: `${indent}px`,
@@ -1937,27 +1937,14 @@ export function PointSummaryGrid({ tree, node, setSelectedTreeKeys }: PointSumma
                         {text}
                     </a>
                 );
+                if (!record.desc.trim()) {
+                    return label;
+                }
+                return <Tooltip title={record.desc}>{label}</Tooltip>;
             },
             onCell: (record) => ({
                 onClick: () => setSelectedTreeKeys([record.key]),
                 style: { cursor: "pointer" },
-            }),
-        },
-        {
-            title: "Description",
-            dataIndex: "desc",
-            key: "desc",
-            onCell: (record: SummaryRecord) => ({
-                style: {
-                    backgroundColor: record.isCovergroup
-                        ? hexToRgba(theme.theme.colors.accentbg.value, 0.2)
-                        : "transparent",
-                    borderLeft: record.isCovergroup
-                        ? `4px solid ${theme.theme.colors.accentbg.value}`
-                        : "none",
-                    fontWeight: record.isCovergroup ? 500 : 400,
-                    paddingLeft: record.isCovergroup ? "12px" : "8px",
-                },
             }),
         },
         {
@@ -2317,14 +2304,6 @@ export function PointSummaryGrid({ tree, node, setSelectedTreeKeys }: PointSumma
                                         Clear filters
                                     </Button>
                                 ) : null}
-                                <Typography.Text
-                                    style={{
-                                        color: colors.primarytxt.value,
-                                        fontSize: 13,
-                                        fontWeight: 500,
-                                    }}>
-                                    Showing {dataSource.length.toLocaleString()} rows
-                                </Typography.Text>
                             </div>
                         )}
                         dataSource={dataSource}
@@ -2333,9 +2312,9 @@ export function PointSummaryGrid({ tree, node, setSelectedTreeKeys }: PointSumma
                                 backgroundColor: record.isCovergroup
                                     ? hexToRgba(theme.theme.colors.accentbg.value, 0.12)
                                     : "transparent",
-                                borderLeft: record.isCovergroup
-                                    ? `3px solid ${theme.theme.colors.accentbg.value}`
-                                    : "3px solid transparent",
+                                boxShadow: record.isCovergroup
+                                    ? `inset 3px 0 0 0 ${theme.theme.colors.accentbg.value}`
+                                    : "none",
                             },
                         })}
                     />

--- a/viewer/src/features/Dashboard/theme.tsx
+++ b/viewer/src/features/Dashboard/theme.tsx
@@ -68,7 +68,15 @@ const sider = {
 };
 
 const body = {
-    props: {} as LayoutProps,
+    props: {
+        style: {
+            display: "flex",
+            flexDirection: "column",
+            flex: "1 1 auto",
+            minHeight: 0,
+            overflow: "hidden",
+        },
+    } as LayoutProps,
     header: {
         props: {
             style: {
@@ -105,8 +113,11 @@ const body = {
         props: {
             style: {
                 margin: 0,
-                minHeight: 280,
-                overflow: "auto", // Use auto instead of scroll - scrollbars hidden via CSS
+                minHeight: 0,
+                flex: "1 1 auto",
+                display: "flex",
+                flexDirection: "column",
+                overflow: "auto",
             },
         } as ComponentPropsWithoutRef<"div">,
         table: {


### PR DESCRIPTION
## Summary
This tightens the **Summary** table on narrow layouts by dropping the dedicated Description column (descriptions show when you **hover the name**) and removes the extra row-count line above the table.

Coverage Info now surfaces overall coverage and hits vs target in one place, so the donut view stays focused on the graphic instead of repeating those numbers underneath.

The donut view is now visually centered based on the real wedge outline (not a phantom full circle), and expanding Coverage Info no longer pushes the chart off the bottom (the chart area shrinks and stays on-screen)