### PR TITLE
Update gitpython dependency version to 3.1.50

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.11"
 dependencies = [
     "rich>=13.3.4",
     "sqlalchemy==2.0.40",
-    "gitpython==3.1.41",
+    "gitpython==3.1.50",
     "click>=8.1.3",
     "pydantic>=2.8.2",
 ]


### PR DESCRIPTION
This intends to resolve security issues like https://github.com/advisories/GHSA-rpm5-65cw-6hj4.  I'll admit that I haven't audited whether this or the related vulnerabilities apply to bucket's use of gitpython, but I'm just being conservative.