### PR TITLE
[None] Preserve Ant table scroll containers

### DIFF
--- a/viewer/src/global.css
+++ b/viewer/src/global.css
@@ -3,12 +3,13 @@
  * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
  */
 
-/* Hide scrollbars for Chrome, Safari and Opera */
-*::-webkit-scrollbar {
+/* Hide scrollbars globally, but keep Ant Table scroll containers measurable.
+ * Safari can misalign sticky/grouped table headers when table scrollbars are forced off. */
+*:not(.ant-table-body):not(.ant-table-content):not(.ant-table-header):not(.ant-table-sticky-scroll)::-webkit-scrollbar {
   display: none;
 }
-/* Hide scrollbars for IE, Edge and Firefox */
-* {
+/* Hide scrollbars for IE, Edge and Firefox (same Ant Table exclusions as above). */
+*:not(.ant-table-body):not(.ant-table-content):not(.ant-table-header):not(.ant-table-sticky-scroll) {
   -ms-overflow-style: none;  /* IE and Edge */
   scrollbar-width: none;  /* Firefox */
 }


### PR DESCRIPTION
## Summary
- Exclude Ant Table scroll containers from the global scrollbar-hiding CSS rules.
- Keeps Safari able to measure table scroll regions so sticky/grouped headers stay aligned.

## Test plan
- Not run; CSS-only change.