### PR TITLE
[Patch] Virtualize the full-feature point table

### DIFF
--- a/viewer/src/features/Dashboard/lib/coveragegrid.tsx
+++ b/viewer/src/features/Dashboard/lib/coveragegrid.tsx
@@ -1178,7 +1178,7 @@ export function PointGrid({ node, compare }: PointGridProps) {
     const [largeCompareCategoryFilter, setLargeCompareCategoryFilter] =
         useState<LargeCompareCategoryFilter>("all");
     const [largeSort, setLargeSort] = useState<LargeSortOption>("bucket_asc");
-    const [largeScrollY, setLargeScrollY] = useState<number>(LARGE_TABLE_SCROLL_Y);
+    const [tableScrollY, setTableScrollY] = useState<number>(LARGE_TABLE_SCROLL_Y);
     const [axisSortState, setAxisSortState] = useState<AxisSortState>({
         axisName: null,
         mode: "none",
@@ -1221,7 +1221,7 @@ export function PointGrid({ node, compare }: PointGridProps) {
             const viewportHeight = window.innerHeight || LARGE_TABLE_SCROLL_Y;
             const reservedHeight = 260;
             const next = Math.max(LARGE_TABLE_SCROLL_Y, viewportHeight - reservedHeight);
-            setLargeScrollY(next);
+            setTableScrollY(next);
         };
 
         updateScrollY();
@@ -1919,7 +1919,7 @@ export function PointGrid({ node, compare }: PointGridProps) {
                                 virtual
                                 scroll={{
                                     x: largeScrollX,
-                                    y: largeScrollY,
+                                    y: tableScrollY,
                                 }}
                             />
                         </>
@@ -1938,6 +1938,9 @@ export function PointGrid({ node, compare }: PointGridProps) {
                     ) ?? []),
                     ...(compare ? getCompareColumns() ?? [] : []),
                 ];
+                const fullScrollX = compare
+                    ? 90 + model.axisModels.length * 160 + 244
+                    : "max-content";
 
                 return (
                     <>
@@ -1953,6 +1956,11 @@ export function PointGrid({ node, compare }: PointGridProps) {
                             onRow={(record) => ({
                                 style: getCompareRowStyle(record.compare_category, compare),
                             })}
+                            virtual
+                            scroll={{
+                                x: fullScrollX,
+                                y: tableScrollY,
+                            }}
                         />
                     </>
                 );


### PR DESCRIPTION
## Summary
- Enable Ant Design virtual scrolling (`virtual` + fixed `scroll.y`) on the full-feature point table, the same mechanism large mode already uses. Only visible rows are rendered to the DOM.
- All full-mode features are retained: per-axis filters (tree filter + search), axis/goal sort menus, grouped headers, coverage cell coloring, and in compare mode the A/B/Category columns and category row tinting.
- Rename `largeScrollY` → `tableScrollY` since the dynamic scroll-height state is now shared by both table modes; the full table's compare-mode `scroll.x` reuses large mode's width formula (`90 + axes×160 + 244`).

This makes "Enable full features" (forced-full) usable on 50k+ bucket points — previously that path rendered every row to the DOM. It also opens the door to raising `POINT_FULL_FEATURE_ROW_LIMIT` or retiring large table mode's parallel column/filter/sort code paths in a follow-up.

## Test plan
Verified manually in the running viewer (dev server + synthetic fixtures from `tools/perf/gen_large_viewer_fixture.py`, plus `example/fixtures/compare_a/b.bktgz`):
- [x] 18k-row point in regular mode: 48 DOM rows for 18,000 data rows; axis filter, sort cycling (asc/desc), and colored cells all work; grouped headers stay aligned
- [x] 200k-row point with "Enable full features": 60fps scrolling (16.7ms avg frame), filter apply ~225ms, sort ~330ms, filter state survives sorting, scroll reaches the true last row
- [x] Compare mode (`play_toys_by_age`): virtualized full table with A/B/Category columns and category row coloring; axis filter + sort compose; set-mode filtering (A only etc.) works, empty intersections show the proper empty state
- [x] Forced-full compare on `cat_nap_multiverse` (51,200 rows): 60fps scroll (16.5ms avg frame), axis filter applies cleanly, headers aligned with `tableLayout=fixed`
- [x] Viewport resize: scroll height tracks the window with the existing 620px floor
- [x] `tsc --noEmit` introduces no new errors (13 pre-existing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)