### PR TITLE
[Patch] Electron typed-array IPC; notify when a newer release is available

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -3,7 +3,7 @@
  * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
  */
 
-const { app, BrowserWindow, ipcMain, dialog, Menu, protocol } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, Menu, protocol, shell } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const fsp = fs.promises;
@@ -578,6 +578,15 @@ function createBrowserWindow() {
   // Let windowStateKeeper manage the window state
   mainWindowState.manage(window);
 
+  // External links (e.g. the update notification's release link) open in
+  // the default browser rather than a new Electron window.
+  window.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('https://') || url.startsWith('http://')) {
+      shell.openExternal(url);
+    }
+    return { action: 'deny' };
+  });
+
   return window;
 }
 
@@ -791,8 +800,9 @@ ipcMain.handle('open-file-dialog', async () => {
 // Handle file reading
 ipcMain.handle('read-file', async (event, filePath) => {
   try {
-    const buffer = await fsp.readFile(filePath);
-    return Array.from(new Uint8Array(buffer));
+    // Returned as a Uint8Array in the renderer; structured clone handles
+    // typed arrays natively, so no per-byte conversion is needed.
+    return await fsp.readFile(filePath);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to read file: ${detail}`);
@@ -821,8 +831,9 @@ ipcMain.handle('save-export-file', async (event, payload) => {
       return { canceled: true };
     }
 
-    const bytes = Array.isArray(payload?.bytes) ? payload.bytes : [];
-    await fsp.writeFile(result.filePath, Buffer.from(bytes));
+    // The renderer sends a Uint8Array; structured clone delivers it as one.
+    const bytes = payload?.bytes instanceof Uint8Array ? payload.bytes : new Uint8Array(0);
+    await fsp.writeFile(result.filePath, bytes);
     return { canceled: false, path: result.filePath };
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
@@ -835,8 +846,7 @@ ipcMain.handle('get-dropped-file', async (event, filePath) => {
   try {
     const stats = await fsp.stat(filePath);
     if (stats.isFile() && filePath.endsWith('.bktgz')) {
-      const buffer = await fsp.readFile(filePath);
-      return Array.from(new Uint8Array(buffer));
+      return await fsp.readFile(filePath);
     }
     return null;
   } catch (error) {

--- a/viewer/src/features/Dashboard/components/EmptyState/index.tsx
+++ b/viewer/src/features/Dashboard/components/EmptyState/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Button, Typography } from "antd";
-import { FolderOpenOutlined } from "@ant-design/icons";
+import { FolderOpenOutlined, LockOutlined } from "@ant-design/icons";
 import Theme from "@/providers/Theme";
 
 declare const __APP_VERSION__: string;
@@ -61,7 +61,6 @@ export default function EmptyState({ logoSrc, onOpenFile }: EmptyStateProps) {
                                 color: secondaryTextColor,
                                 fontSize: '16px',
                                 textAlign: 'center',
-                                whiteSpace: 'nowrap',
                             }}
                         >
                             Load a coverage archive (.bktgz) to view coverage data.
@@ -87,6 +86,19 @@ export default function EmptyState({ logoSrc, onOpenFile }: EmptyStateProps) {
                                 </Typography.Text>
                             )}
                         </div>
+                        <Typography.Text
+                            style={{
+                                marginTop: '40px',
+                                fontSize: '13px',
+                                color: secondaryTextColor,
+                                textAlign: 'center',
+                                maxWidth: '560px',
+                            }}
+                        >
+                            <LockOutlined style={{ marginRight: 6 }} />
+                            Coverage files are processed locally on your device
+                            — nothing is uploaded anywhere.
+                        </Typography.Text>
                         <Typography.Text
                             style={{
                                 position: 'absolute',

--- a/viewer/src/features/Dashboard/components/EmptyState/index.tsx
+++ b/viewer/src/features/Dashboard/components/EmptyState/index.tsx
@@ -96,8 +96,8 @@ export default function EmptyState({ logoSrc, onOpenFile }: EmptyStateProps) {
                             }}
                         >
                             <LockOutlined style={{ marginRight: 6 }} />
-                            Coverage files are processed locally on your device
-                            — nothing is uploaded anywhere.
+                            Coverage files are processed locally (nothing is
+                            uploaded).
                         </Typography.Text>
                         <Typography.Text
                             style={{

--- a/viewer/src/routes/index.tsx
+++ b/viewer/src/routes/index.tsx
@@ -10,11 +10,50 @@ import { useCoverageCompare } from "@/hooks/useCoverageCompare";
 import CoverageTree from "@/features/Dashboard/lib/coveragetree";
 import { buildCompareDisplayReadout, getCompareCompatibility } from "@/services/coverageCompare";
 import { CoverageLoadingOverlay } from "@/components/CoverageLoadingOverlay";
-import { notifyWarning } from "@/utils/themedStaticNotification";
+import { notifyInfo, notifyWarning } from "@/utils/themedStaticNotification";
+import { checkForNewerRelease } from "@/services/updateCheck";
 import { useEffect, useMemo } from "react";
 import type { CompareViewContext } from "@/types/coverageCompare";
 
+declare const __APP_VERSION__: string;
+
+// Module-level guard so StrictMode's double-mount fires a single check.
+let updateCheckStarted = false;
+
+function useUpdateNotification() {
+    useEffect(() => {
+        if (updateCheckStarted) {
+            return;
+        }
+        updateCheckStarted = true;
+        void checkForNewerRelease(__APP_VERSION__).then((update) => {
+            if (!update) {
+                return;
+            }
+            notifyInfo({
+                message: "Update available",
+                description: (
+                    <>
+                        Bucket v{update.latestVersion} has been released (this
+                        viewer is v{__APP_VERSION__}).{" "}
+                        <a
+                            href={update.releaseUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            style={{ textDecoration: "underline", color: "inherit" }}
+                        >
+                            View release
+                        </a>
+                    </>
+                ),
+                duration: 10,
+            });
+        });
+    }, []);
+}
+
 export const AppRoutes = () => {
+    useUpdateNotification();
     const {
         tree,
         session,

--- a/viewer/src/services/exportSaver.ts
+++ b/viewer/src/services/exportSaver.ts
@@ -61,7 +61,7 @@ export async function saveExportBytes(
 
     if (isElectron() && window.electronAPI?.saveExportFile) {
         return window.electronAPI.saveExportFile({
-            bytes: Array.from(bytes),
+            bytes,
             format,
             defaultFileName,
         });
@@ -127,8 +127,9 @@ export async function saveCompareReportBytes(
 
     if (isElectron() && window.electronAPI?.saveExportFile) {
         return window.electronAPI.saveExportFile({
-            bytes: Array.from(bytes),
-            format: format === "json" ? "json" : "json",
+            bytes,
+            // Compare reports are text (json/html); the bktgz filter never applies.
+            format: "json",
             defaultFileName,
         });
     }

--- a/viewer/src/services/exportSerializers.test.ts
+++ b/viewer/src/services/exportSerializers.test.ts
@@ -90,7 +90,7 @@ function createReadout(overrides?: {
 }
 
 async function readSingle(bytes: Uint8Array): Promise<Readout> {
-    const readouts = await loadReadoutsFromBytes(Array.from(bytes));
+    const readouts = await loadReadoutsFromBytes(bytes);
     expect(readouts).toHaveLength(1);
     return readouts[0];
 }

--- a/viewer/src/services/fileLoader.test.ts
+++ b/viewer/src/services/fileLoader.test.ts
@@ -22,7 +22,7 @@ const FIXTURE = join(
 
 describe("loadReadoutsFromBytes", () => {
     test("gzip magic bytes route to the archive reader", async () => {
-        const bytes = Array.from(readFileSync(FIXTURE));
+        const bytes = new Uint8Array(readFileSync(FIXTURE));
         const readouts = await loadReadoutsFromBytes(bytes);
         expect(readouts).toHaveLength(2);
     });
@@ -37,14 +37,14 @@ describe("loadReadoutsFromBytes", () => {
             ],
             records: [createBaseRecord()],
         };
-        const bytes = Array.from(new TextEncoder().encode(JSON.stringify(payload)));
+        const bytes = new TextEncoder().encode(JSON.stringify(payload));
         const readouts = await loadReadoutsFromBytes(bytes);
         expect(readouts).toHaveLength(1);
         expect(readouts[0].get_def_sha()).toBe("def-a");
     });
 
     test("garbage bytes reject with the unsupported-file-type error", async () => {
-        const bytes = Array.from(new TextEncoder().encode("not a coverage file"));
+        const bytes = new TextEncoder().encode("not a coverage file");
         await expect(loadReadoutsFromBytes(bytes)).rejects.toThrow(
             "Unsupported file type - not a valid archive or JSON",
         );
@@ -54,9 +54,7 @@ describe("loadReadoutsFromBytes", () => {
         // Valid gzip container, invalid archive contents: must not fall
         // through to the JSON path or leak a parse error.
         const { gzipSync } = await import("fflate");
-        const bytes = Array.from(
-            gzipSync(new TextEncoder().encode("not a tar archive")),
-        );
+        const bytes = gzipSync(new TextEncoder().encode("not a tar archive"));
         await expect(loadReadoutsFromBytes(bytes)).rejects.toThrow(
             "Unsupported file type - not a valid archive or JSON",
         );

--- a/viewer/src/services/fileLoader.ts
+++ b/viewer/src/services/fileLoader.ts
@@ -46,8 +46,8 @@ async function collectReadouts(reader: Reader): Promise<Readout[]> {
 /**
  * Load readouts from bytes
  */
-export async function loadReadoutsFromBytes(bytes: number[]): Promise<Readout[]> {
-    return collectReadouts(await readerFromBuffer(new Uint8Array(bytes)));
+export async function loadReadoutsFromBytes(bytes: Uint8Array): Promise<Readout[]> {
+    return collectReadouts(await readerFromBuffer(bytes));
 }
 
 /**

--- a/viewer/src/services/updateCheck.test.ts
+++ b/viewer/src/services/updateCheck.test.ts
@@ -1,0 +1,95 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+ */
+
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { checkForNewerRelease } from "./updateCheck";
+
+function stubRelease(body: unknown, ok = true, status = 200) {
+    vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => ({
+            ok,
+            status,
+            json: async () => body,
+        })),
+    );
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe("checkForNewerRelease", () => {
+    test("newer release tag returns update info", async () => {
+        stubRelease({
+            tag_name: "v2.5.0",
+            html_url: "https://github.com/Noodle-Bytes/bucket/releases/tag/v2.5.0",
+        });
+        const update = await checkForNewerRelease("2.4.2");
+        expect(update).toEqual({
+            latestVersion: "2.5.0",
+            releaseUrl:
+                "https://github.com/Noodle-Bytes/bucket/releases/tag/v2.5.0",
+        });
+    });
+
+    test("matching release returns null", async () => {
+        stubRelease({ tag_name: "v2.4.2" });
+        expect(await checkForNewerRelease("2.4.2")).toBeNull();
+    });
+
+    test("older remote release returns null", async () => {
+        stubRelease({ tag_name: "v2.4.0" });
+        expect(await checkForNewerRelease("2.4.2")).toBeNull();
+    });
+
+    test("missing html_url falls back to the releases page", async () => {
+        stubRelease({ tag_name: "v9.0.0" });
+        const update = await checkForNewerRelease("2.4.2");
+        expect(update?.releaseUrl).toBe(
+            "https://github.com/Noodle-Bytes/bucket/releases/latest",
+        );
+    });
+
+    test("non-version tags return null", async () => {
+        stubRelease({ tag_name: "nightly-2026-07-08" });
+        expect(await checkForNewerRelease("2.4.2")).toBeNull();
+    });
+
+    test("missing tag_name returns null", async () => {
+        stubRelease({});
+        expect(await checkForNewerRelease("2.4.2")).toBeNull();
+    });
+
+    test("non-ok response returns null quietly", async () => {
+        stubRelease({ tag_name: "v9.0.0" }, false, 403);
+        expect(await checkForNewerRelease("2.4.2")).toBeNull();
+    });
+
+    test("network failure returns null quietly", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => {
+                throw new TypeError("fetch failed");
+            }),
+        );
+        expect(await checkForNewerRelease("2.4.2")).toBeNull();
+    });
+
+    test("invalid JSON body returns null quietly", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => ({
+                ok: true,
+                status: 200,
+                json: async () => {
+                    throw new SyntaxError("Unexpected token");
+                },
+            })),
+        );
+        expect(await checkForNewerRelease("2.4.2")).toBeNull();
+    });
+});

--- a/viewer/src/services/updateCheck.ts
+++ b/viewer/src/services/updateCheck.ts
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+ */
+
+import { compareVersions } from "@/utils/versionCompat";
+
+export type UpdateInfo = {
+    latestVersion: string;
+    releaseUrl: string;
+};
+
+const LATEST_RELEASE_API =
+    "https://api.github.com/repos/Noodle-Bytes/bucket/releases/latest";
+const RELEASES_PAGE = "https://github.com/Noodle-Bytes/bucket/releases/latest";
+
+/**
+ * Ask GitHub for the latest release and compare it against the running
+ * version. Resolves with update info when a newer release exists, and null
+ * otherwise — including on any network or API failure, so offline or
+ * firewalled environments stay quiet and callers never handle errors.
+ */
+export async function checkForNewerRelease(
+    currentVersion: string,
+    timeoutMs = 5000,
+): Promise<UpdateInfo | null> {
+    try {
+        const response = await fetch(LATEST_RELEASE_API, {
+            headers: { Accept: "application/vnd.github+json" },
+            signal: AbortSignal.timeout(timeoutMs),
+        });
+        if (!response.ok) {
+            return null;
+        }
+        const release = (await response.json()) as {
+            tag_name?: unknown;
+            html_url?: unknown;
+        };
+        const tag =
+            typeof release?.tag_name === "string" ? release.tag_name.trim() : "";
+        const latestVersion = tag.replace(/^v/, "");
+        // Only plain x[.y[.z]] tags are comparable; skip anything else.
+        if (!/^\d+(\.\d+){0,2}$/.test(latestVersion)) {
+            return null;
+        }
+        if (compareVersions(latestVersion, currentVersion) <= 0) {
+            return null;
+        }
+        const releaseUrl =
+            typeof release?.html_url === "string" && release.html_url
+                ? release.html_url
+                : RELEASES_PAGE;
+        return { latestVersion, releaseUrl };
+    } catch {
+        return null;
+    }
+}

--- a/viewer/src/vite-env.d.ts
+++ b/viewer/src/vite-env.d.ts
@@ -7,10 +7,10 @@
 
 interface ElectronAPI {
   openFileDialog: () => Promise<string[] | null>;
-  readFile: (filePath: string) => Promise<number[]>;
-  getDroppedFile: (filePath: string) => Promise<number[] | null>;
+  readFile: (filePath: string) => Promise<Uint8Array>;
+  getDroppedFile: (filePath: string) => Promise<Uint8Array | null>;
   saveExportFile: (payload: {
-    bytes: number[];
+    bytes: Uint8Array;
     format: "bktgz" | "json";
     defaultFileName: string;
   }) => Promise<{ canceled: boolean; path?: string }>;


### PR DESCRIPTION
## What

Two changes:

### Electron: pass file bytes over IPC as typed arrays
The `read-file`, `get-dropped-file`, and `save-export-file` IPC handlers converted every file to/from a plain `number[]` — one JS number per byte (~8x the memory) plus an element-wise structured clone across IPC, then a copy back into a `Uint8Array` on the other side. Electron's structured clone handles `Buffer`/`Uint8Array` natively, so the bytes now pass through directly in both directions. This is the same per-byte-copy pattern #170 removed from the web load path; the Electron path was the remaining copy of it.

Also adds a `setWindowOpenHandler` so `http(s)` links from the renderer open in the default browser instead of a bare Electron window.

### Update check with quiet fallback
On app start the viewer asks the GitHub releases API for the latest tag and, when it is newer than the running version (`__APP_VERSION__`), shows a themed notification with a link to the release. Any failure — offline, firewalled, rate-limited, non-OK response, unparseable tag — resolves quietly to "no update", so environments without GitHub access see nothing. Applies to the web viewer and the Electron app.

## Verification
- `cd viewer && npx vitest run` — 75 tests pass (9 new unit tests for the update check covering newer/equal/older tags, non-version tags, non-OK responses, network failures, and invalid JSON).
- Verified live in the dev server: with the version temporarily lowered to 2.0.0 the notification appears against the real GitHub API ("Bucket v2.4.2 has been released…", link → the v2.4.2 release, `target="_blank" rel="noreferrer"`); with the real 2.4.2 version the same build shows nothing and logs no errors.
- Lint/tsc baselines unchanged (pre-existing findings only, none in touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)