### PR TITLE
[Patch] Fix wheel/sdist packaging of the viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,9 @@ example_*.db
 
 dist/
 dev-dist/
-index.html
+# Demo report written at the repo root; anchored so the pattern doesn't also
+# exclude viewer/index.html (hatchling applies these patterns to builds).
+/index.html
 
 # macOS
 .DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,19 @@ bucket = "bucket.__main__:cli"
 [tool.hatch.version]
 source = "vcs"
 
+# The viewer is bundled by `npm run bundle` at report time (bucket/rw/html.py),
+# so distributions ship its sources but never the generated directories.
+# Nested viewer/.gitignore is not consulted by hatchling, so exclude them
+# explicitly here.
+[tool.hatch.build]
+exclude = [
+    "viewer/node_modules",
+    "viewer/dist",
+    "viewer/dev-dist",
+    "viewer/coverage",
+]
+
 [tool.hatch.build.targets.wheel]
-packages = ["bucket"]
-include = ["viewer/**/*"]
+# `packages` is sugar for `only-include`, which limits traversal to the listed
+# paths; a plain `include` of viewer files would never match. List both roots.
+only-include = ["bucket", "viewer"]


### PR DESCRIPTION
## What changed

- **pyproject.toml**: added a shared `[tool.hatch.build]` exclude for `viewer/node_modules`, `viewer/dist`, `viewer/dev-dist`, and `viewer/coverage` (applies to both sdist and wheel), and switched the wheel target from `packages = ["bucket"]` + `include = ["viewer/**/*"]` to `only-include = ["bucket", "viewer"]`.
- **.gitignore**: anchored the demo-report pattern to `/index.html` so it no longer matches `viewer/index.html`.

## Why

`uv build` took minutes and produced a bloated artifact. Investigating turned up three related packaging bugs:

1. **The sdist was the bloated artifact.** The sdist target had no config, and hatchling does not read nested ignore files like `viewer/.gitignore`, so `viewer/node_modules` and `viewer/coverage` were swept into the tarball (confirmed by planting dummy files, which appeared in the sdist).
2. **The wheel never shipped the viewer at all.** In hatchling, `packages = ["bucket"]` is sugar for `only-include`, which restricts file traversal to `bucket/` — so `include = ["viewer/**/*"]` never matched anything and published wheels contained zero viewer files.
3. **`viewer/index.html` was silently excluded from builds.** The root `.gitignore` had an unanchored `index.html` entry (meant for the demo report written at the repo root), and hatchling applies those patterns to file selection — dropping the vite entry point from the sdist.

Shipping only built assets is not an option: `HTMLWriter` (bucket/rw/html.py) runs `npm run bundle` at report time to inject the coverage JSON, so distributions need the viewer *source* tree installed at `site-packages/viewer`, which is where both `HTMLWriter`'s default `web_path` and the CLI's `--web-path` default resolve.

## Verification

- `uv build` completes in ~2.5s.
- Wheel is 306K: `bucket/` + 85 viewer source files (including `index.html`, `package.json`, `vite-bundle.config.ts`, `src/`, `public/`); no generated directories.
- Sdist is 2.4M with `viewer/index.html` present; planted `node_modules`/`dist`/`dev-dist`/`coverage` dummies were excluded.
- Installed the wheel into a fresh venv: `bucket --help` works and `HTMLWriter`'s default `web_path` resolves to an existing `site-packages/viewer` containing `index.html` and `package.json`.

## Reviewer notes

- Published wheels previously contained no viewer, so wheel installs failed fast at the `npm ls` check in `HTMLWriter`. With this change they instead reach the intended `npm install`-dependent report-generation path; wheel size grows from 42K to 306K.
- The `.gitignore` anchoring only affects nested `index.html` files; `viewer/index.html` was already tracked, and the demo report at the repo root remains ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)