### PR TITLE
[None] Bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/deploy-viewer.yml
+++ b/.github/workflows/deploy-viewer.yml
@@ -25,14 +25,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Full history so the viewer's git-describe version fallback works
           # on workflow_dispatch runs (tag pushes set BUCKET_VERSION directly).
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: "npm"
@@ -52,7 +52,7 @@ jobs:
           BUCKET_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -63,7 +63,7 @@ jobs:
         run: mkdocs build -d viewer/dist/docs
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: viewer/dist
 
@@ -76,4 +76,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/tag-release-on-merge.yml
+++ b/.github/workflows/tag-release-on-merge.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Checkout main with full history and tags
         if: steps.bump.outputs.bump != 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,12 @@ jobs:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       # Full history and tags so hatch-vcs can derive the package version.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -43,11 +43,11 @@ jobs:
         working-directory: ./viewer
     steps:
       # Full history and tags so __APP_VERSION__ resolves via git describe.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
## What changed

Bumped all Node 20-targeting actions across the three workflows that use them to their current majors:

| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-node | v4 | v6 |
| actions/setup-python | v5 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |

## Why

The v2.4.5 deploy run ([28969365516](https://github.com/Noodle-Bytes/bucket/actions/runs/28969365516)) — like every other recent run — completed with warning annotations: these action versions target the Node.js 20 runtime, which GitHub deprecated on hosted runners in September 2025 and now forces onto Node 24. The `upload-artifact@v4` mentioned in the warning is bundled inside `upload-pages-artifact@v3`, hence that bump.

## Breaking-change review

- **setup-node v6** limits automatic caching to npm only — this repo only uses `cache: "npm"` (deploy-viewer.yml), so no impact.
- **checkout v7** blocks checking out fork PR heads on `pull_request_target`/`workflow_run` events — the only `pull_request_target` workflow here (tag-release-on-merge.yml) checks out `ref: main` explicitly, so no impact.
- **setup-python v6**, **deploy-pages v5**, **upload-pages-artifact v5** are Node 24 runtime bumps (requiring runner ≥ 2.327.1, which GitHub-hosted runners satisfy).

The remaining action (`create-github-app-token`, SHA-pinned) was not flagged in the warnings and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)