### PR TITLE
[Patch] Fix tier and tags overrides chained before add_coverpoint

### DIFF
--- a/bucket/coverpoint.py
+++ b/bucket/coverpoint.py
@@ -102,9 +102,14 @@ class Coverpoint(CoverBase):
         # Instance of Bucket class to increment hit count for a bucket
         self.bucket = Bucket(parent=self, log=log)
 
-        self._tier = 0
+        tier_explicit = getattr(self, "_tier_explicit", False)
+        tags_explicit = getattr(self, "_tags_explicit", False)
+        if not tier_explicit:
+            self._tier = 0
+        if not tags_explicit:
+            self._tags = []
+
         self._tier_active = True
-        self._tags = []
 
         self._setup()
         self._name = name or self.NAME or type(self).__name__
@@ -141,8 +146,10 @@ class Coverpoint(CoverBase):
         This calls the user defined setup() plus any other setup required
         """
         self.setup(ctx=CoverageContext.get())
-        self.set_tags(self.TAGS)
-        self.set_tier(self.TIER)
+        if not getattr(self, "_tags_explicit", False):
+            self._tags = list(self.TAGS)
+        if not getattr(self, "_tier_explicit", False):
+            self._tier = self.TIER
 
     def setup(self, ctx: SimpleNamespace):
         """
@@ -155,18 +162,23 @@ class Coverpoint(CoverBase):
     def set_tier(self, tier):
         """Set coverpoint tier"""
         self._tier = tier
+        self._tier_explicit = True
         return self
 
     @validate_call
     def set_tags(self, tags: TagStrs):
         """Override coverpoint tags with only those provided"""
         self._tags = tags
+        self._tags_explicit = True
         return self
 
     @validate_call
     def add_tags(self, tags: TagStrs):
         """Add coverpoint tags to existing ones"""
+        if not getattr(self, "_tags_explicit", False):
+            self._tags = []
         self._tags += tags
+        self._tags_explicit = True
         return self
 
     def _set_tier_level(self, tier: int):

--- a/tests/test_coverpoint_tier_tags.py
+++ b/tests/test_coverpoint_tier_tags.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+from bucket import Covergroup, Coverpoint, Covertop
+
+
+class DefaultTierTagsCoverpoint(Coverpoint):
+    TIER = 2
+    TAGS = ["class_default"]
+
+    def setup(self, ctx):
+        self.add_axis("value", values=[0, 1], description="Test axis")
+
+    def sample(self, trace):
+        pass
+
+
+class ChainedTierTagsCoverpoint(Coverpoint):
+    TIER = 0
+    TAGS = ["class_default"]
+
+    def setup(self, ctx):
+        self.add_axis("value", values=[0, 1], description="Test axis")
+
+    def sample(self, trace):
+        pass
+
+
+class SetupTierCoverpoint(Coverpoint):
+    TIER = 0
+
+    def setup(self, ctx):
+        self.add_axis("value", values=[0, 1], description="Test axis")
+        self.set_tier(4)
+
+    def sample(self, trace):
+        pass
+
+
+class TierTagsCovergroup(Covergroup):
+    NAME = "tier_tags_cg"
+
+    def setup(self, ctx):
+        self.add_coverpoint(DefaultTierTagsCoverpoint())
+        self.add_coverpoint(
+            ChainedTierTagsCoverpoint().set_tier(5).set_tags(["toys", "age", "legs"])
+        )
+        self.add_coverpoint(SetupTierCoverpoint())
+
+
+class TierTagsTop(Covertop):
+    NAME = "tier_tags_top"
+
+    def setup(self, ctx):
+        self.add_covergroup(TierTagsCovergroup())
+
+
+def test_coverpoint_uses_class_tier_and_tags_by_default():
+    top = TierTagsTop()
+    cp = top.tier_tags_cg.DefaultTierTagsCoverpoint
+    assert cp._tier == 2
+    assert cp._tags == ["class_default"]
+
+
+def test_coverpoint_preserves_tier_and_tags_chained_before_add_coverpoint():
+    top = TierTagsTop()
+    cp = top.tier_tags_cg.ChainedTierTagsCoverpoint
+    assert cp._tier == 5
+    assert cp._tags == ["toys", "age", "legs"]
+
+
+def test_coverpoint_set_tier_in_setup_is_preserved():
+    top = TierTagsTop()
+    cp = top.tier_tags_cg.SetupTierCoverpoint
+    assert cp._tier == 4


### PR DESCRIPTION
## Summary
- Preserve `set_tier()`, `set_tags()`, and `add_tags()` values when chained before `add_coverpoint()`
- Only apply class-level `TIER` and `TAGS` defaults when no explicit override was set
- Also preserves `set_tier()` called from within `setup()`

Fixes a bug where `_init()` always reset tier/tags from class attributes, breaking the pattern used in `example/dogs.py` and documented in the user docs.

## Test plan
- [x] `pytest tests/test_coverpoint_tier_tags.py`
- [ ] Confirm `ChewToysByAgeAndFavLeg().set_tier(5).set_tags(...)` in `example/dogs.py` retains tier 5 after covertree build