### PR TITLE
[Minor] Version the storage format independently of the bucket release

### DIFF
--- a/bucket/rw/archive.py
+++ b/bucket/rw/archive.py
@@ -4,11 +4,12 @@
 import csv
 import tarfile
 import tempfile
-import warnings
 from pathlib import Path
 from typing import Iterable, NamedTuple, overload
 
 from .common import (
+    ARCHIVE_FORMAT_VERSION,
+    LEGACY_FORMAT_VERSION,
     Accessor,
     AxisTuple,
     AxisValueTuple,
@@ -21,22 +22,9 @@ from .common import (
     Reader,
     Readout,
     Writer,
-    _get_bucket_version,
+    check_format_version,
     point_tuple_from_row,
 )
-
-
-def _parse_version(v: str) -> tuple[int, ...]:
-    """Parse a version string into a tuple of ints for comparison."""
-    parts = []
-    for p in v.split(".")[:3]:
-        try:
-            parts.append(int(p))
-        except ValueError:
-            parts.append(0)
-    while len(parts) < 3:
-        parts.append(0)
-    return tuple(parts)
 
 
 class ArchiveDefinitionTuple(NamedTuple):
@@ -63,6 +51,9 @@ class ArchiveRecordTuple(NamedTuple):
     source: str  # Stored as "" in CSV, always a string
     source_key: str  # Stored as "" in CSV, always a string
     bucket_version: str = ""  # Version of bucket that wrote this record
+    # Storage format the record was written with; rows predating format
+    # versioning omit the column and default to the legacy format.
+    format_version: int = LEGACY_FORMAT_VERSION
 
 
 DEFINITION_PATH = "definition"
@@ -158,28 +149,9 @@ class ArchiveReadout(Readout):
         )
         self.definition = ArchiveDefinitionTuple(*definition_row)
 
-        file_version = self.record.bucket_version or ""
-        if file_version:
-            installed = _get_bucket_version()
-            if installed != "unknown":
-                fv = _parse_version(file_version)
-                iv = _parse_version(installed)
-                if fv > iv:
-                    warnings.warn(
-                        f"Coverage file was generated with bucket v{file_version}, which is "
-                        f"newer than the installed version (v{installed}). "
-                        "Some data may not be read correctly.",
-                        UserWarning,
-                        stacklevel=2,
-                    )
-                elif fv < iv:
-                    warnings.warn(
-                        f"Coverage file was generated with an older version of bucket "
-                        f"(v{file_version}); installed version is v{installed}. "
-                        "The reader is broadly backwards compatible.",
-                        UserWarning,
-                        stacklevel=2,
-                    )
+        self._format_version = check_format_version(
+            self.record.format_version, ARCHIVE_FORMAT_VERSION
+        )
 
     def get_def_sha(self) -> str:
         return self.definition.def_sha
@@ -195,6 +167,9 @@ class ArchiveReadout(Readout):
 
     def get_bucket_version(self) -> str:
         return self.record.bucket_version or ""
+
+    def get_format_version(self) -> int:
+        return self._format_version
 
     def iter_points(
         self, start: int = 0, end: int | None = None, depth: int = 0
@@ -377,6 +352,10 @@ class ArchiveWriter(Writer):
                         source,
                         source_key,
                         bucket_version,
+                        # Always stamp the writer's own format, not the
+                        # readout's: it describes how these bytes are laid
+                        # out, not where the data came from.
+                        ARCHIVE_FORMAT_VERSION,
                     )
                 ],
             )

--- a/bucket/rw/common.py
+++ b/bucket/rw/common.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
 
 import json
+import warnings
 from datetime import datetime
 from importlib.metadata import PackageNotFoundError as _PKGNotFound
 from importlib.metadata import version as _pkg_version
@@ -16,6 +17,70 @@ def _get_bucket_version() -> str:
         return _pkg_version("bucket")
     except _PKGNotFound:
         return "unknown"
+
+
+# Version of the on-disk storage formats, independent of the bucket package
+# version. Bump ONLY when a serialized layout changes (columns added or
+# removed, encodings changed, etc.) — never for feature releases that leave
+# the stored bytes untouched. Readers warn based on this value alone, so a
+# bump is a signal to users that a file and their installed reader may not
+# fully understand each other.
+#
+# The archive (.bktgz) and JSON formats each carry their own version field
+# and are checked by their own reader, but by policy the two counters always
+# bump in LOCKSTEP: a change to either layout moves both constants to the
+# same new value (recorded in the shared history below). This keeps "format
+# vN" meaning one thing across the project while still letting each file
+# type be checked independently.
+#
+# Keep in sync with SUPPORTED_FORMAT_VERSION in
+# viewer/src/utils/versionCompat.ts.
+#
+# Format history:
+#   1: original layout; archive record rows may omit the trailing
+#      bucket_version and format_version columns, JSON records carry no
+#      version keys
+#   2: archive record rows carry the format_version column; JSON records
+#      carry the bucket_version and format_version keys
+FORMAT_VERSION = 2
+ARCHIVE_FORMAT_VERSION = FORMAT_VERSION
+JSON_FORMAT_VERSION = FORMAT_VERSION
+
+# Oldest format the readers still fully support.
+MIN_FORMAT_VERSION = 1
+
+# Files written before format versioning was introduced are format 1.
+LEGACY_FORMAT_VERSION = 1
+
+
+def check_format_version(raw_version, current: int) -> int:
+    """
+    Coerce a stored format version to an int and warn if it falls outside
+    the range this reader supports. Returns the coerced version.
+    """
+    try:
+        file_format = int(raw_version)
+    except (TypeError, ValueError):
+        file_format = LEGACY_FORMAT_VERSION
+
+    if file_format > current:
+        warnings.warn(
+            f"Coverage file uses storage format v{file_format}, which is "
+            f"newer than this version of bucket supports (up to v{current}). "
+            "Some data may not be read correctly; update bucket to fully "
+            "support this file.",
+            UserWarning,
+            stacklevel=3,
+        )
+    elif file_format < MIN_FORMAT_VERSION:
+        warnings.warn(
+            f"Coverage file uses storage format v{file_format}, which is "
+            f"older than the minimum this version of bucket supports "
+            f"(v{MIN_FORMAT_VERSION}). Some data may not be read correctly.",
+            UserWarning,
+            stacklevel=3,
+        )
+    return file_format
 
 
 ###############################################################################
@@ -232,6 +297,7 @@ class Readout(Protocol):
     def get_source(self) -> str: ...
     def get_source_key(self) -> str: ...
     def get_bucket_version(self) -> str: ...
+    def get_format_version(self) -> int: ...
     def iter_points(
         self, start: int = 0, end: int | None = None, depth: int = 0
     ) -> Iterable[PointTuple]: ...
@@ -635,6 +701,7 @@ class PuppetReadout(Readout):
         self._source: str = ""
         self._source_key: str = ""
         self.bucket_version: str = ""
+        self.format_version: int = FORMAT_VERSION
 
     def get_def_sha(self) -> str:
         if self.def_sha is None:
@@ -670,6 +737,9 @@ class PuppetReadout(Readout):
 
     def get_bucket_version(self) -> str:
         return self.bucket_version
+
+    def get_format_version(self) -> int:
+        return self.format_version
 
     def iter_points(
         self, start: int = 0, end: int | None = None, depth: int = 0
@@ -749,6 +819,11 @@ class MergeReadout(Readout):
 
     def get_bucket_version(self) -> str:
         return self._bucket_version
+
+    def get_format_version(self) -> int:
+        # Merged data is held in memory, so it is (re)serialized at whatever
+        # format the writer that stores it uses.
+        return FORMAT_VERSION
 
     def iter_points(
         self, start: int = 0, end: int | None = None, depth: int = 0

--- a/bucket/rw/json.py
+++ b/bucket/rw/json.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Iterable, overload
 
 from .common import (
+    JSON_FORMAT_VERSION,
     Accessor,
     AxisTuple,
     AxisValueTuple,
@@ -19,6 +20,7 @@ from .common import (
     Reader,
     Readout,
     Writer,
+    check_format_version,
     point_tuple_from_row,
 )
 
@@ -80,6 +82,11 @@ class JSONWriter(Writer):
                 "sha": readout.get_rec_sha(),
                 "source": readout.get_source(),
                 "source_key": readout.get_source_key(),
+                "bucket_version": readout.get_bucket_version(),
+                # Always stamp the writer's own format, not the readout's:
+                # it describes how this record is laid out, not where the
+                # data came from.
+                "format_version": JSON_FORMAT_VERSION,
                 "point_hit": [list(it) for it in readout.iter_point_hits()],
                 "bucket_hit": [list(it) for it in readout.iter_bucket_hits()],
             }
@@ -113,6 +120,12 @@ class JSONReader(Reader):
         readout.rec_sha = record["sha"]
         readout.source = record.get("source", "")
         readout.source_key = record.get("source_key", "")
+        readout.bucket_version = record.get("bucket_version") or ""
+        # Records predating format versioning have no key and read as the
+        # legacy format.
+        readout.format_version = check_format_version(
+            record.get("format_version"), JSON_FORMAT_VERSION
+        )
         readout.def_sha = definition["sha"]
 
         readout.points = [point_tuple_from_row(p) for p in definition["point"]]

--- a/tests/test_rw/test_format_version.py
+++ b/tests/test_rw/test_format_version.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+
+import csv
+import json
+import tarfile
+import tempfile
+import warnings
+from pathlib import Path
+
+import pytest
+
+from bucket.rw import ArchiveAccessor, JSONAccessor
+from bucket.rw.archive import (
+    RECORD_PATH,
+    ArchiveDefinitionTuple,
+    ArchiveReadout,
+    ArchiveRecordTuple,
+)
+from bucket.rw.common import (
+    ARCHIVE_FORMAT_VERSION,
+    FORMAT_VERSION,
+    JSON_FORMAT_VERSION,
+    LEGACY_FORMAT_VERSION,
+    AxisTuple,
+    AxisValueTuple,
+    BucketGoalTuple,
+    BucketHitTuple,
+    GoalTuple,
+    PointHitTuple,
+    PointTuple,
+)
+
+from ..utils import GeneratedReadout
+
+
+def _write_archive(tmpdir: Path) -> Path:
+    path = tmpdir / "storage.bktgz"
+    ArchiveAccessor(path).write(GeneratedReadout(def_seed=1, rec_seed=1))
+    return path
+
+
+def _extract_archive(archive_path: Path, dest: Path) -> Path:
+    with tarfile.open(archive_path, mode="r:gz") as tar:
+        tar.extractall(dest, filter="data")
+    return dest
+
+
+def _rewrite_record_rows(extracted: Path, mutate) -> None:
+    """Apply `mutate` to every row of the extracted record table."""
+    record_path = extracted / RECORD_PATH
+    rows = list(
+        csv.reader(record_path.read_text().splitlines(), quoting=csv.QUOTE_NONNUMERIC)
+    )
+    with record_path.open("w", newline="") as f:
+        csv.writer(f, quoting=csv.QUOTE_NONNUMERIC).writerows(
+            mutate(row) for row in rows
+        )
+
+
+class TestFormatVersion:
+    def test_layout_change_requires_format_bump(self):
+        """
+        Snapshot of the serialized row layouts. If this test fails, the
+        on-disk storage format has changed: bump FORMAT_VERSION in
+        bucket/rw/common.py (and SUPPORTED_FORMAT_VERSION in
+        viewer/src/utils/versionCompat.ts), document the change in the
+        format history, then update this snapshot.
+        """
+        assert FORMAT_VERSION == 2
+        # The archive and JSON formats are versioned independently but by
+        # policy always bump in lockstep.
+        assert ARCHIVE_FORMAT_VERSION == FORMAT_VERSION
+        assert JSON_FORMAT_VERSION == FORMAT_VERSION
+        assert ArchiveDefinitionTuple._fields == (
+            "def_sha",
+            "point_offset",
+            "point_end",
+            "axis_offset",
+            "axis_end",
+            "axis_value_offset",
+            "axis_value_end",
+            "goal_offset",
+            "goal_end",
+            "bucket_goal_offset",
+            "bucket_goal_end",
+        )
+        assert ArchiveRecordTuple._fields == (
+            "rec_sha",
+            "definition_offset",
+            "point_hit_offset",
+            "point_hit_end",
+            "bucket_hit_offset",
+            "bucket_hit_end",
+            "source",
+            "source_key",
+            "bucket_version",
+            "format_version",
+        )
+        assert PointTuple._fields == (
+            "start",
+            "depth",
+            "end",
+            "axis_start",
+            "axis_end",
+            "axis_value_start",
+            "axis_value_end",
+            "goal_start",
+            "goal_end",
+            "bucket_start",
+            "bucket_end",
+            "target",
+            "target_buckets",
+            "name",
+            "description",
+            "tier",
+            "tags",
+            "motivation",
+        )
+        assert AxisTuple._fields == (
+            "start",
+            "value_start",
+            "value_end",
+            "name",
+            "description",
+        )
+        assert AxisValueTuple._fields == ("start", "value")
+        assert GoalTuple._fields == ("start", "target", "name", "description")
+        assert BucketGoalTuple._fields == ("start", "goal")
+        assert PointHitTuple._fields == (
+            "start",
+            "depth",
+            "hits",
+            "hit_buckets",
+            "full_buckets",
+        )
+        assert BucketHitTuple._fields == ("start", "hits")
+
+    def test_writer_stamps_current_format(self):
+        """A written archive records the current format and reads silently."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_archive(Path(tmpdir))
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                readout = ArchiveAccessor(path).read(0)
+            assert readout.get_format_version() == FORMAT_VERSION
+
+    def test_bucket_version_mismatch_does_not_warn(self):
+        """
+        A different bucket release writing the same format must not warn:
+        the package version is provenance only.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            extracted = _extract_archive(_write_archive(tmp), tmp / "unpacked")
+
+            def set_ancient_bucket(row):
+                row[8] = "0.0.1"
+                return row
+
+            _rewrite_record_rows(extracted, set_ancient_bucket)
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                readout = ArchiveReadout(extracted, 0)
+            assert readout.get_bucket_version() == "0.0.1"
+            assert readout.get_format_version() == FORMAT_VERSION
+
+    def test_legacy_record_without_format_column_is_silent(self):
+        """Rows written before format versioning read as the legacy format."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            extracted = _extract_archive(_write_archive(tmp), tmp / "unpacked")
+
+            _rewrite_record_rows(extracted, lambda row: row[:9])
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                readout = ArchiveReadout(extracted, 0)
+            assert readout.get_format_version() == LEGACY_FORMAT_VERSION
+
+    def test_newer_format_warns(self):
+        """A file from a future format warns that the reader is behind."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            extracted = _extract_archive(_write_archive(tmp), tmp / "unpacked")
+
+            def bump_format(row):
+                row[9] = FORMAT_VERSION + 1
+                return row
+
+            _rewrite_record_rows(extracted, bump_format)
+
+            with pytest.warns(UserWarning, match="storage format"):
+                readout = ArchiveReadout(extracted, 0)
+            assert readout.get_format_version() == FORMAT_VERSION + 1
+
+
+def _write_json(tmpdir: Path) -> Path:
+    path = tmpdir / "storage.json"
+    readout = GeneratedReadout(def_seed=1, rec_seed=1)
+    readout.bucket_version = "9.9.9"
+    JSONAccessor(path).write(readout)
+    return path
+
+
+def _rewrite_json_records(path: Path, mutate) -> None:
+    data = json.loads(path.read_text())
+    data["records"] = [mutate(record) for record in data["records"]]
+    path.write_text(json.dumps(data))
+
+
+class TestJSONFormatVersion:
+    def test_writer_stamps_current_format(self):
+        """A written JSON file records the current format and reads silently."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_json(Path(tmpdir))
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                readout = JSONAccessor(path).read(0)
+            assert readout.get_format_version() == JSON_FORMAT_VERSION
+            assert readout.get_bucket_version() == "9.9.9"
+
+    def test_legacy_record_without_version_keys_is_silent(self):
+        """Records written before format versioning read as the legacy format."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_json(Path(tmpdir))
+
+            def strip_versions(record):
+                record.pop("bucket_version")
+                record.pop("format_version")
+                return record
+
+            _rewrite_json_records(path, strip_versions)
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                readout = JSONAccessor(path).read(0)
+            assert readout.get_format_version() == LEGACY_FORMAT_VERSION
+            assert readout.get_bucket_version() == ""
+
+    def test_newer_format_warns(self):
+        """A JSON file from a future format warns that the reader is behind."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = _write_json(Path(tmpdir))
+
+            def bump_format(record):
+                record["format_version"] = JSON_FORMAT_VERSION + 1
+                return record
+
+            _rewrite_json_records(path, bump_format)
+
+            with pytest.warns(UserWarning, match="storage format"):
+                readout = JSONAccessor(path).read(0)
+            assert readout.get_format_version() == JSON_FORMAT_VERSION + 1

--- a/viewer/src/features/Dashboard/index.tsx
+++ b/viewer/src/features/Dashboard/index.tsx
@@ -67,7 +67,7 @@ import { hexToRgba } from "@/utils/colors";
 import { buildBucketAntModalTheme } from "@/utils/bucketAntModalTheme";
 import type { CoverageRecord, CoverageSourceRef, ExportFormat } from "@/types/coverageSession";
 import { getDefaultExportFileName } from "@/services/exportSaver";
-import { checkVersionCompat } from "@/utils/versionCompat";
+import { checkFormatCompat } from "@/utils/versionCompat";
 import CompareToolbar from "./components/CompareToolbar";
 import type { PointData, PointNode } from "./lib/coveragetree";
 import { getPointNodeCompareCounts, getPointNodeCoverageMetrics } from "./lib/coveragemetrics";
@@ -98,6 +98,7 @@ type RootCoverageInfo = {
     defSha: string | null;
     recSha: string | null;
     bucketVersion: string | null;
+    formatVersion: number | null;
 };
 
 type TopLevelCoverageCounts = {
@@ -189,6 +190,7 @@ function getTopLevelCoverageInfo(
         defSha: getReadoutValue(readout, "get_def_sha"),
         recSha: getReadoutValue(readout, "get_rec_sha"),
         bucketVersion: readout.get_bucket_version?.() || null,
+        formatVersion: readout.get_format_version?.() ?? null,
     };
 }
 
@@ -321,7 +323,7 @@ function TopLevelCoverageInfoPanel({
         setVersionAlertDismissed(false);
     }, [treeSelectionKey]);
 
-    const compat = checkVersionCompat(info.bucketVersion, __APP_VERSION__);
+    const compat = checkFormatCompat(info.formatVersion);
 
     const dismissVersionAlert = useCallback(() => {
         setVersionAlertDismissed(true);
@@ -367,21 +369,14 @@ function TopLevelCoverageInfoPanel({
                         colors={colors}
                         caution
                         onDismiss={dismissVersionAlert}
-                        text={`This file was created with bucket ${compat.fileVersion}, which is newer than this viewer (${compat.viewerVersion}).`}
+                        text={`This file uses coverage storage format v${compat.fileFormat}, which is newer than this viewer supports (up to v${compat.supportedFormat}). Some data may not display correctly — try updating the viewer.`}
                     />
                 ) : compat.status === "file_older" ? (
                     <BucketVersionCompatAlert
                         colors={colors}
-                        caution={false}
-                        onDismiss={dismissVersionAlert}
-                        text={`This file was created with an older bucket (${compat.fileVersion}). The viewer is broadly backwards compatible.`}
-                    />
-                ) : compat.status === "unknown" ? (
-                    <BucketVersionCompatAlert
-                        colors={colors}
                         caution
                         onDismiss={dismissVersionAlert}
-                        text="This file doesn’t say which bucket release created it. The viewer is broadly backwards compatible."
+                        text={`This file uses coverage storage format v${compat.fileFormat}, which this viewer no longer supports (minimum v${compat.minSupportedFormat}). Some data may not display correctly.`}
                     />
                 ) : null;
                 const chromeColors = {
@@ -470,6 +465,15 @@ function TopLevelCoverageInfoPanel({
                                                 <CoverageInfoField
                                                     label="Bucket Version"
                                                     value={info.bucketVersion}
+                                                    colors={colors}
+                                                />
+                                                <CoverageInfoField
+                                                    label="Storage Format"
+                                                    value={
+                                                        info.formatVersion === null
+                                                            ? null
+                                                            : `v${info.formatVersion}`
+                                                    }
                                                     colors={colors}
                                                 />
                                             </div>

--- a/viewer/src/features/Dashboard/lib/readers.test.ts
+++ b/viewer/src/features/Dashboard/lib/readers.test.ts
@@ -5,8 +5,15 @@
 
 import { describe, expect, test } from "vitest";
 
-import { parseCsvTable, parseCsvTableBytes, readJsonBytes } from "./readers";
 import {
+    ArchiveReader,
+    ParsedArchiveTables,
+    parseCsvTable,
+    parseCsvTableBytes,
+    readJsonBytes,
+} from "./readers";
+import {
+    BASE_POINT_COLUMNS,
     JsonPayload,
     createBaseDefinition,
     createBaseRecord,
@@ -220,5 +227,80 @@ describe("parseCsvTable", () => {
         const bytes = parseCsvTableBytes(data);
         expect(fast.rows).toEqual(bytes.rows);
         expect(Array.from(fast.offsets)).toEqual(Array.from(bytes.offsets));
+    });
+});
+
+describe("archive record format version", () => {
+    const emptyTable = () => ({ rows: [], offsets: [] });
+
+    function buildTables(recordRows: (string | number)[][]): ParsedArchiveTables {
+        return {
+            definition: {
+                rows: [["defsha", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                offsets: [0],
+            },
+            record: {
+                rows: recordRows,
+                offsets: recordRows.map((_, idx) => idx),
+            },
+            point: emptyTable(),
+            axis: emptyTable(),
+            axis_value: emptyTable(),
+            goal: emptyTable(),
+            bucket_goal: emptyTable(),
+            point_hit: emptyTable(),
+            bucket_hit: emptyTable(),
+        };
+    }
+
+    test("reads the format version column when present", async () => {
+        const reader = ArchiveReader.fromParsedTables(
+            buildTables([["recsha", 0, 0, 0, 0, 0, "", "", "1.2.3", 2]]),
+        );
+        const readout = await reader.read(0);
+        expect(readout.get_format_version?.()).toBe(2);
+        expect(readout.get_bucket_version()).toBe("1.2.3");
+    });
+
+    test("legacy rows without the column default to format 1", async () => {
+        const legacyRows = [
+            // pre-bucket_version row
+            ["recsha", 0, 0, 0, 0, 0, "", ""],
+            // bucket_version but no format_version
+            ["recsha", 0, 0, 0, 0, 0, "", "", "0.9.0"],
+        ];
+        const reader = ArchiveReader.fromParsedTables(buildTables(legacyRows));
+        const first = await reader.read(0);
+        const second = await reader.read(1);
+        expect(first.get_format_version?.()).toBe(1);
+        expect(second.get_format_version?.()).toBe(1);
+    });
+});
+
+describe("json record format version", () => {
+    test("reads the version keys when present", async () => {
+        const payload: JsonPayload = {
+            tables: createCommonTables(BASE_POINT_COLUMNS),
+            definitions: [createBaseDefinition([
+                0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, "root", "point",
+            ])],
+            records: [createBaseRecord({ bucket_version: "1.2.3", format_version: 2 })],
+        };
+        const readout = await readSingle(payload);
+        expect(readout.get_format_version?.()).toBe(2);
+        expect(readout.get_bucket_version()).toBe("1.2.3");
+    });
+
+    test("legacy records without version keys default to format 1", async () => {
+        const payload: JsonPayload = {
+            tables: createCommonTables(BASE_POINT_COLUMNS),
+            definitions: [createBaseDefinition([
+                0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1, 1, "root", "point",
+            ])],
+            records: [createBaseRecord()],
+        };
+        const readout = await readSingle(payload);
+        expect(readout.get_format_version?.()).toBe(1);
+        expect(readout.get_bucket_version()).toBe("");
     });
 });

--- a/viewer/src/features/Dashboard/lib/readers.ts
+++ b/viewer/src/features/Dashboard/lib/readers.ts
@@ -5,6 +5,8 @@
 
 import { gunzipSync } from "fflate";
 
+import { LEGACY_FORMAT_VERSION } from "@/utils/versionCompat";
+
 type JSONDefinition = {
     sha: string,
 } & {[key:string]: (string | number | null)[][]};
@@ -14,6 +16,8 @@ type JSONRecord = {
     sha: string,
     source?: string | null,
     source_key?: string | null,
+    bucket_version?: string | null,
+    format_version?: number | string | null,
 } & {[key:string]: (string | number | null)[][]};
 
 type JSONTables = Record<string, string[]>;
@@ -47,7 +51,14 @@ export class JSONReadout implements Readout {
         return this.record.source_key ?? null;
     }
     get_bucket_version(): string {
-        return "";
+        return this.record.bucket_version == null
+            ? ""
+            : String(this.record.bucket_version);
+    }
+    get_format_version(): number {
+        // Records predating format versioning have no key and read as the
+        // legacy format.
+        return toFormatVersion(this.record.format_version ?? null);
     }
     private *iter_def_table<T extends Record<string, unknown>>(table: string, start: number=0, end: number | null=null): Generator<T> {
         const keys = this.tables[table];
@@ -172,6 +183,7 @@ type ArchiveRecord = {
     source: string | null;  // Stored as "" in CSV, converted to null when reading
     source_key: string | null;  // Stored as "" in CSV, converted to null when reading
     bucket_version: string;  // Version of bucket that wrote this record ("" if unknown)
+    format_version: number;  // Storage format of the record (legacy rows omit the column)
 };
 
 type ArchiveTableMap = Record<ArchiveTableName, ArchiveTable>;
@@ -275,6 +287,10 @@ export class ArchiveReadout implements Readout {
 
     get_bucket_version(): string {
         return this.record.bucket_version;
+    }
+
+    get_format_version(): number {
+        return this.record.format_version;
     }
 
     *iter_points(
@@ -523,6 +539,7 @@ function toArchiveRecord(row: (string | number)[]): ArchiveRecord {
         source: source === "" ? null : toString(source),
         source_key: source_key === "" ? null : toString(source_key),
         bucket_version: row.length > 8 ? toString(row[8]) : "",
+        format_version: toFormatVersion(row.length > 9 ? row[9] : null),
     };
 }
 
@@ -858,6 +875,14 @@ function toNumber(value: string | number): number {
 
 function toString(value: string | number): string {
     return typeof value === "string" ? value : String(value);
+}
+
+function toFormatVersion(value: string | number | null): number {
+    if (value === null || value === "") {
+        return LEGACY_FORMAT_VERSION;
+    }
+    const parsed = toNumber(value);
+    return Number.isFinite(parsed) ? parsed : LEGACY_FORMAT_VERSION;
 }
 
 export function readJsonBytes(buffer: Uint8Array): JSONReader {

--- a/viewer/src/services/exportSerializers.test.ts
+++ b/viewer/src/services/exportSerializers.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, expect, test } from "vitest";
 import { InMemoryReadout, mergeReadoutsStrict } from "@/services/readoutUtils";
+import { SUPPORTED_FORMAT_VERSION } from "@/utils/versionCompat";
 import {
     serializeReadoutsToArchiveBytes,
     serializeReadoutsToJsonBytes,
@@ -158,6 +159,7 @@ describe("export serializers", () => {
         expect(Array.from(restored.iter_bucket_hits(0, null)).map((value) => value.hits)).toEqual(
             [5, 6],
         );
+        expect(restored.get_format_version?.()).toBe(SUPPORTED_FORMAT_VERSION);
     });
 
     test("round-trips archive serialization through reader", async () => {
@@ -183,5 +185,6 @@ describe("export serializers", () => {
         expect(Array.from(restored.iter_bucket_hits(0, null)).map((value) => value.hits)).toEqual(
             [7, 8],
         );
+        expect(restored.get_format_version?.()).toBe(SUPPORTED_FORMAT_VERSION);
     });
 });

--- a/viewer/src/services/exportSerializers.ts
+++ b/viewer/src/services/exportSerializers.ts
@@ -6,6 +6,7 @@
 import { gzipSync } from "fflate";
 import type { ExportFormat } from "@/types/coverageSession";
 import { materializeReadout } from "@/services/readoutUtils";
+import { SUPPORTED_FORMAT_VERSION } from "@/utils/versionCompat";
 
 type JsonCoverageData = {
     tables: Record<string, string[]>;
@@ -201,6 +202,10 @@ export function serializeReadoutsToJsonBytes(readouts: Readout[]): Uint8Array {
             sha: data.recSha,
             source: data.source,
             source_key: data.sourceKey,
+            bucket_version: data.bucketVersion ?? "",
+            // Always stamp the serializer's own format, not the source
+            // readout's: it describes how this record is laid out.
+            format_version: SUPPORTED_FORMAT_VERSION,
             point_hit: data.pointHits.map((pointHit) => [
                 pointHit.start,
                 pointHit.depth,
@@ -316,6 +321,10 @@ export function serializeReadoutsToArchiveBytes(readouts: Readout[]): Uint8Array
                 bucketHitSpan.end,
                 data.source ?? "",
                 data.sourceKey ?? "",
+                data.bucketVersion ?? "",
+                // Always stamp the serializer's own format, not the source
+                // readout's: it describes how this record row is laid out.
+                SUPPORTED_FORMAT_VERSION,
             ],
         ]);
     }

--- a/viewer/src/services/readoutUtils.ts
+++ b/viewer/src/services/readoutUtils.ts
@@ -9,6 +9,7 @@ type MaterializedReadoutData = {
     source: string | null;
     sourceKey: string | null;
     bucketVersion: string;
+    formatVersion?: number | null;
     points: PointTuple[];
     bucketGoals: BucketGoalTuple[];
     axes: AxisTuple[];
@@ -75,6 +76,10 @@ export class InMemoryReadout implements Readout {
 
     get_bucket_version(): string {
         return this.data.bucketVersion;
+    }
+
+    get_format_version(): number | null {
+        return this.data.formatVersion ?? null;
     }
 
     *iter_points(
@@ -148,6 +153,7 @@ export function materializeReadout(readout: Readout): MaterializedReadoutData {
         source: readout.get_source(),
         sourceKey: readout.get_source_key(),
         bucketVersion: readout.get_bucket_version(),
+        formatVersion: readout.get_format_version?.() ?? null,
         points: Array.from(readout.iter_points()).map(clonePointTuple),
         bucketGoals: Array.from(readout.iter_bucket_goals(0, null)).map(cloneBucketGoalTuple),
         axes: Array.from(readout.iter_axes(0, null)).map(cloneAxisTuple),
@@ -263,6 +269,7 @@ export function mergeCompareReadoutsForDisplay(readoutA: Readout, readoutB: Read
         source: "Compare merged (A+B)",
         sourceKey: "",
         bucketVersion: master.bucketVersion,
+        formatVersion: master.formatVersion ?? null,
         points: master.points,
         bucketGoals: master.bucketGoals,
         axes: master.axes,
@@ -325,6 +332,7 @@ export function mergeReadoutsStrict(readouts: Readout[]): Readout {
         source: getMergedSourceName(),
         sourceKey: "",
         bucketVersion: master.bucketVersion,
+        formatVersion: master.formatVersion ?? null,
         points: master.points,
         bucketGoals: master.bucketGoals,
         axes: master.axes,

--- a/viewer/src/types/coverage.ts
+++ b/viewer/src/types/coverage.ts
@@ -68,6 +68,8 @@ type Readout = {
     get_source: () => string | null;
     get_source_key: () => string | null;
     get_bucket_version: () => string;
+    /** Storage format the record was written with; null when not stated. */
+    get_format_version?: () => number | null;
     iter_points: (
         start?: number,
         end?: number | null,

--- a/viewer/src/utils/versionCompat.test.ts
+++ b/viewer/src/utils/versionCompat.test.ts
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2023-2026 Noodle-Bytes. All Rights Reserved
+ */
+
+import { describe, expect, test } from "vitest";
+
+import {
+    MIN_SUPPORTED_FORMAT_VERSION,
+    SUPPORTED_FORMAT_VERSION,
+    checkFormatCompat,
+    compareVersions,
+} from "./versionCompat";
+
+describe("checkFormatCompat", () => {
+    test("supported formats match silently", () => {
+        for (
+            let format = MIN_SUPPORTED_FORMAT_VERSION;
+            format <= SUPPORTED_FORMAT_VERSION;
+            format += 1
+        ) {
+            expect(checkFormatCompat(format)).toEqual({ status: "match" });
+        }
+    });
+
+    test("missing format version is treated as legacy and matches", () => {
+        expect(checkFormatCompat(null)).toEqual({ status: "match" });
+        expect(checkFormatCompat(undefined)).toEqual({ status: "match" });
+        expect(checkFormatCompat(Number.NaN)).toEqual({ status: "match" });
+    });
+
+    test("newer format than supported is flagged", () => {
+        expect(checkFormatCompat(SUPPORTED_FORMAT_VERSION + 1)).toEqual({
+            status: "file_newer",
+            fileFormat: SUPPORTED_FORMAT_VERSION + 1,
+            supportedFormat: SUPPORTED_FORMAT_VERSION,
+        });
+    });
+
+    test("format below the supported minimum is flagged", () => {
+        expect(checkFormatCompat(MIN_SUPPORTED_FORMAT_VERSION - 1)).toEqual({
+            status: "file_older",
+            fileFormat: MIN_SUPPORTED_FORMAT_VERSION - 1,
+            minSupportedFormat: MIN_SUPPORTED_FORMAT_VERSION,
+        });
+    });
+});
+
+describe("compareVersions", () => {
+    test("orders semver-like strings", () => {
+        expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
+        expect(compareVersions("1.2.3", "1.2.4")).toBe(-1);
+        expect(compareVersions("1.10.0", "1.9.9")).toBe(1);
+    });
+});

--- a/viewer/src/utils/versionCompat.ts
+++ b/viewer/src/utils/versionCompat.ts
@@ -25,61 +25,53 @@ export function compareVersions(a: string, b: string): -1 | 0 | 1 {
 }
 
 /**
- * Compare major.minor only (patch is ignored).
- * Used for viewer/file compatibility warnings so patch drift does not alert.
+ * Storage format versions the viewer understands. The format version is
+ * independent of the bucket/viewer release version and is only bumped when
+ * the on-disk layout of coverage files actually changes.
+ *
+ * The archive (.bktgz) and JSON formats each carry their own version field,
+ * but by policy their counters always bump in lockstep (see the format
+ * history in bucket/rw/common.py), so a single supported range covers both.
+ *
+ * Keep in sync with FORMAT_VERSION / MIN_FORMAT_VERSION in
+ * bucket/rw/common.py.
  */
-function compareMajorMinor(a: string, b: string): -1 | 0 | 1 {
-    const parseTwo = (v: string) => {
-        const parts = v.split(".").slice(0, 2);
-        const maj = parseInt(parts[0] ?? "", 10) || 0;
-        const min = parseInt(parts[1] ?? "", 10) || 0;
-        return [maj, min] as const;
-    };
+export const SUPPORTED_FORMAT_VERSION = 2;
+export const MIN_SUPPORTED_FORMAT_VERSION = 1;
 
-    const [aMaj, aMin] = parseTwo(a);
-    const [bMaj, bMin] = parseTwo(b);
+/** Files written before format versioning are format 1. */
+export const LEGACY_FORMAT_VERSION = 1;
 
-    if (aMaj !== bMaj) return aMaj > bMaj ? 1 : -1;
-    if (aMin !== bMin) return aMin > bMin ? 1 : -1;
-    return 0;
-}
-
-export type VersionCompatResult =
-    | { status: "unknown" }
+export type FormatCompatResult =
     | { status: "match" }
-    | { status: "file_older"; fileVersion: string; viewerVersion: string }
-    | { status: "file_newer"; fileVersion: string; viewerVersion: string };
-
-/** Trimmed value missing or a placeholder — treat as unknown embedding (warn like compat gap). */
-function isUnsetTrimmedBucketVersion(t: string): boolean {
-    if (!t) {
-        return true;
-    }
-    return /^(unknown|unversioned|n\/a|na|none)$/i.test(t);
-}
+    | { status: "file_newer"; fileFormat: number; supportedFormat: number }
+    | { status: "file_older"; fileFormat: number; minSupportedFormat: number };
 
 /**
- * Determine compatibility between the version embedded in a coverage file
- * and the version of the viewer.
- *
- * Only **major** and **minor** are compared for mismatch warnings; differing
- * **patch** alone is treated as compatible (no banner).
+ * Determine compatibility between the storage format of a coverage file and
+ * the range of formats this viewer supports. A missing format version means
+ * the file predates format versioning and is treated as the legacy format.
  */
-export function checkVersionCompat(
-    fileVersion: string | null | undefined,
-    viewerVersion: string,
-): VersionCompatResult {
-    const raw =
-        typeof fileVersion === "string" ? fileVersion.trim() : "";
-    if (isUnsetTrimmedBucketVersion(raw)) {
-        return { status: "unknown" };
+export function checkFormatCompat(
+    fileFormat: number | null | undefined,
+): FormatCompatResult {
+    const format =
+        typeof fileFormat === "number" && Number.isFinite(fileFormat)
+            ? fileFormat
+            : LEGACY_FORMAT_VERSION;
+    if (format > SUPPORTED_FORMAT_VERSION) {
+        return {
+            status: "file_newer",
+            fileFormat: format,
+            supportedFormat: SUPPORTED_FORMAT_VERSION,
+        };
     }
-    const cmp = compareMajorMinor(raw, viewerVersion);
-    if (cmp === 0) {
-        return { status: "match" };
+    if (format < MIN_SUPPORTED_FORMAT_VERSION) {
+        return {
+            status: "file_older",
+            fileFormat: format,
+            minSupportedFormat: MIN_SUPPORTED_FORMAT_VERSION,
+        };
     }
-    if (cmp < 0) {
-        return { status: "file_older", fileVersion: raw, viewerVersion };
-    }
-    return { status: "file_newer", fileVersion: raw, viewerVersion };
+    return { status: "match" };
 }

--- a/viewer/vite-bundle.config.ts
+++ b/viewer/vite-bundle.config.ts
@@ -34,6 +34,12 @@ export default defineConfig(async () => {
         define: {
             __BUCKET_CVG_JSON: coverage,
             __APP_VERSION__: JSON.stringify(resolveBucketVersion()),
-        }
+        },
+        // Web workers are bundled separately and do not inherit `plugins`,
+        // so "@/..." imports inside the worker graph (archiveWorker ->
+        // readers -> versionCompat) need their own tsconfig-paths instance.
+        worker: {
+            plugins: () => [tsconfigPaths()],
+        },
     }
 });

--- a/viewer/vite.config.ts
+++ b/viewer/vite.config.ts
@@ -106,5 +106,11 @@ export default defineConfig((env) => {
         tsconfigPaths(),
         getPluginPWA(env)
         ],
+        // Web workers are bundled separately and do not inherit `plugins`,
+        // so "@/..." imports inside the worker graph (archiveWorker ->
+        // readers -> versionCompat) need their own tsconfig-paths instance.
+        worker: {
+            plugins: () => [tsconfigPaths()],
+        },
     }
 });


### PR DESCRIPTION
## Summary

- Versions the on-disk/archive storage format independently of the bucket release version, so the storage schema can evolve without being coupled to package releases.
- Resolves tsconfig `@/` path aliases inside Vite worker bundles (worker bundles don't inherit top-level `plugins`), fixing a production build failure where `archiveWorker → readers → versionCompat` couldn't be resolved.

## Test plan

- [x] `cd viewer && npm run build` succeeds (worker bundle resolves `@/utils/versionCompat`)
- [x] Viewer + Python suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)