### PR TITLE
[Patch] Fix overlapping columns in the virtualized full-feature point table

### DIFF
--- a/viewer/src/features/Dashboard/lib/coveragegrid.tsx
+++ b/viewer/src/features/Dashboard/lib/coveragegrid.tsx
@@ -805,7 +805,9 @@ function getFullColumns(
             ),
             dataIndex: "key",
             key: "key",
-            width: compare ? 90 : 1,
+            // Virtualized tables lay columns out at their literal pixel
+            // widths, so every column needs a real width (no auto-fit).
+            width: 90,
             onCell: getNowrapCellProps,
         },
         {
@@ -843,7 +845,7 @@ function getFullColumns(
                     ),
                     dataIndex: axis.name,
                     key: axis.name,
-                    ...(compare ? { width: 160 } : {}),
+                    width: 160,
                     filters: axisValueSlice.map((axisValue) => ({
                         text: axisValue.value,
                         value: axisValue.value,
@@ -897,6 +899,7 @@ function getFullColumns(
                     ),
                     dataIndex: "goal_name",
                     key: "goal_name",
+                    width: 180,
                     filters: model.goals.map((goal) => ({
                         text: `${goal.name} - ${goal.description}`,
                         value: goal.name,
@@ -938,6 +941,7 @@ function getFullColumns(
                     ),
                     dataIndex: "target",
                     key: "target",
+                    width: 120,
                 },
                 {
                     title: (
@@ -972,6 +976,7 @@ function getFullColumns(
                     ),
                     dataIndex: "hits",
                     key: "hits",
+                    width: 100,
                 },
                 {
                     title: (
@@ -1007,6 +1012,7 @@ function getFullColumns(
                     ),
                     dataIndex: "hit_ratio",
                     key: "hit_ratio",
+                    width: 120,
                     filters: [
                         { text: "Full", value: "full" },
                         { text: "Partial", value: "partial" },
@@ -1959,9 +1965,12 @@ export function PointGrid({ node, compare }: PointGridProps) {
         ) : null;
 
         if (isLargeMode) {
+            // Virtual tables require a numeric scroll.x (strings such as
+            // "max-content" are clamped to 1px, collapsing the layout), so
+            // sum the explicit column widths for each mode.
             const largeScrollX = compare
                 ? 90 + model.axisModels.length * 160 + 244
-                : "max-content";
+                : 72 + model.axisModels.length * 140 + 460;
             return (
                 <>
                     {pointMetadata}
@@ -1986,9 +1995,10 @@ export function PointGrid({ node, compare }: PointGridProps) {
             );
         }
 
+        // See largeScrollX: virtual tables require a numeric scroll.x.
         const fullScrollX = compare
             ? 90 + model.axisModels.length * 160 + 244
-            : "max-content";
+            : 90 + model.axisModels.length * 160 + 520;
 
         return (
             <>
@@ -1998,7 +2008,7 @@ export function PointGrid({ node, compare }: PointGridProps) {
                 <Table<CoverageRecord>
                     {...(view.body.content.table.props as unknown as TableProps<CoverageRecord>)}
                     key={`${node.key}-${compare ? "compare" : "normal"}`}
-                    tableLayout={compare ? "fixed" : "auto"}
+                    tableLayout="fixed"
                     columns={fullColumns}
                     dataSource={sortedFullDataSource}
                     onRow={(record) => ({


### PR DESCRIPTION
## Summary

Since the full-feature point table was virtualized (#168), the ID column has rendered 1px wide with its `nowrap` text painting over the first axis column, so bucket IDs and axis values appeared superimposed.

Ant Design virtual tables lay columns out at their **literal** pixel widths — they don't auto-size to content. The full table still carried its pre-virtualization auto-layout config:

- `width: 1` on the ID column (the old shrink-to-fit hack for `table-layout: auto`)
- no widths on the axis and goal columns
- `scroll.x: "max-content"`, which rc-table clamps to **1px** in virtual mode (`VirtualTable` warns "`scroll.x` in virtual table must be number")

## Changes

- Give every full-table column an explicit width: ID 90, axes 160, Name 180, Hits needed 120, Hits 100, Hit % 120.
- Compute a numeric `scroll.x` from the column widths for both the full and large tables (large mode's columns already had widths, so it only emitted the warning).
- Set the full table to `tableLayout="fixed"` unconditionally, matching the known-good compare path, now that all columns have widths.

When the widths sum to less than the viewport, rc-table scales columns proportionally, so wide windows still fill edge-to-edge.

## Testing

- Loaded the example archive (`python -m example.example`) in the dev viewer and opened `play_toys_by_age`: IDs and axis values each render in their own column at 1280px and 700px viewports.
- Measured header vs body cell rects programmatically: identical x/width for every column, and they stay in sync after horizontal scroll.
- Console is clean — the rc-table `scroll.x` warning is gone.
- `npx eslint` on the file passes.

## Note for reviewers

Columns no longer auto-fit their content (inherent to virtualization): very long axis values now ellipsis at 160px instead of widening the column. If that becomes a problem, a follow-up could derive per-axis widths from the longest value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)